### PR TITLE
refactor(nvidia-nim): use standard OAuth for authentication

### DIFF
--- a/extensions/nvidia-nim/index.ts
+++ b/extensions/nvidia-nim/index.ts
@@ -1,12 +1,12 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { OAuthCredentials, OAuthLoginCallbacks } from "@mariozechner/pi-ai/dist/utils/oauth/types.js";
 import * as fs from "node:fs/promises";
 import * as fsSync from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 
-/** Persisted config shape */
-export interface NvidiaNimConfig {
-  apiKey: string;
+/** Persisted model config (API key is now managed via OAuth in ~/.pi/agent/auth.json) */
+export interface NvidiaModelsConfig {
   models: NvidiaModelEntry[];
 }
 
@@ -36,12 +36,14 @@ export function getConfigPath(): string {
   return path.join(os.homedir(), ".pi", "nvidia-nim.json");
 }
 
-export async function loadConfig(): Promise<NvidiaNimConfig | null> {
+/** Load models config from ~/.pi/nvidia-nim.json (async).
+ *  Handles both new format (models only) and legacy format (with apiKey). */
+export async function loadModelsConfig(): Promise<NvidiaModelsConfig | null> {
   try {
     const content = await fs.readFile(getConfigPath(), "utf-8");
     const parsed = JSON.parse(content);
-    if (parsed.apiKey && Array.isArray(parsed.models)) {
-      return parsed as NvidiaNimConfig;
+    if (Array.isArray(parsed.models) && parsed.models.length > 0) {
+      return { models: parsed.models };
     }
     return null;
   } catch {
@@ -49,13 +51,14 @@ export async function loadConfig(): Promise<NvidiaNimConfig | null> {
   }
 }
 
-/** Synchronous version for use during extension init (before Pi finishes loading) */
-export function loadConfigSync(): NvidiaNimConfig | null {
+/** Synchronous version for use during extension init (before Pi finishes loading).
+ *  Handles both new format (models only) and legacy format (with apiKey). */
+export function loadModelsConfigSync(): NvidiaModelsConfig | null {
   try {
     const content = fsSync.readFileSync(getConfigPath(), "utf-8");
     const parsed = JSON.parse(content);
-    if (parsed.apiKey && Array.isArray(parsed.models)) {
-      return parsed as NvidiaNimConfig;
+    if (Array.isArray(parsed.models) && parsed.models.length > 0) {
+      return { models: parsed.models };
     }
     return null;
   } catch {
@@ -63,7 +66,7 @@ export function loadConfigSync(): NvidiaNimConfig | null {
   }
 }
 
-export async function saveConfig(config: NvidiaNimConfig): Promise<void> {
+export async function saveModelsConfig(config: NvidiaModelsConfig): Promise<void> {
   const configPath = getConfigPath();
   await fs.mkdir(path.dirname(configPath), { recursive: true });
   await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
@@ -100,42 +103,6 @@ function formatModelName(id: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-/** Get the path to ~/.pi/agent/settings.json */
-export function getAgentSettingsPath(): string {
-  return path.join(os.homedir(), ".pi", "agent", "settings.json");
-}
-
-/**
- * Add nvidia model IDs to enabledModels in ~/.pi/agent/settings.json
- * so they show up in the scoped /model view and Ctrl+P cycling.
- * Removes any stale nvidia/ entries first, then appends the new ones.
- */
-export async function updateEnabledModels(models: NvidiaModelEntry[]): Promise<void> {
-  const settingsPath = getAgentSettingsPath();
-
-  let settings: Record<string, any> = {};
-  try {
-    const content = await fs.readFile(settingsPath, "utf-8");
-    if (content.trim()) {
-      settings = JSON.parse(content);
-    }
-  } catch (err: any) {
-    if (err.code !== "ENOENT") throw err;
-  }
-
-  const existing: string[] = Array.isArray(settings.enabledModels) ? settings.enabledModels : [];
-
-  // Remove old nvidia/ entries
-  const filtered = existing.filter((id: string) => !id.startsWith(`${NVIDIA_PROVIDER_NAME}/`));
-
-  // Add new nvidia models with provider prefix
-  const nvidiaIds = models.map((m) => `${NVIDIA_PROVIDER_NAME}/${m.id}`);
-  settings.enabledModels = [...filtered, ...nvidiaIds];
-
-  await fs.mkdir(path.dirname(settingsPath), { recursive: true });
-  await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), "utf-8");
-}
-
 /**
  * Fetch available model IDs from the Nvidia NIM API.
  * Returns the set of valid model IDs, or null on failure.
@@ -154,122 +121,91 @@ export async function fetchAvailableModels(apiKey: string): Promise<Set<string> 
   }
 }
 
-/** Register the nvidia provider with pi so models appear in /model */
-export function registerProvider(pi: ExtensionAPI, config: NvidiaNimConfig): void {
-  pi.registerProvider("nvidia", {
-    baseUrl: NVIDIA_BASE_URL,
-    apiKey: config.apiKey,
-    api: "openai-completions",
-    models: config.models.map((m) => ({
-      id: m.id,
-      name: m.name,
-      reasoning: m.reasoning,
-      input: ["text"] as ("text" | "image")[],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 128000,
-      maxTokens: 16384,
-    })),
-  });
+/** Build the provider model descriptors from our model entries. */
+function buildModelDescriptors(models: NvidiaModelEntry[]) {
+  return models.map((m) => ({
+    id: m.id,
+    name: m.name,
+    reasoning: m.reasoning,
+    input: ["text"] as ("text" | "image")[],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 16384,
+  }));
+}
+
+/** Build the OAuth config for Nvidia NIM API key authentication. */
+function buildOAuthConfig() {
+  return {
+    name: "Nvidia NIM",
+
+    async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+      const apiKey = await callbacks.onPrompt({
+        message: "Enter your Nvidia NIM API key (nvapi-... from build.nvidia.com):",
+        placeholder: "nvapi-...",
+      });
+
+      if (!apiKey?.trim()) {
+        throw new Error("API key is required. Get one at https://build.nvidia.com");
+      }
+
+      const key = apiKey.trim();
+
+      // Validate by hitting the models endpoint
+      const res = await fetch(`${NVIDIA_BASE_URL}/models`, {
+        headers: { Authorization: `Bearer ${key}` },
+      });
+      if (!res.ok) {
+        throw new Error(
+          `API key validation failed (HTTP ${res.status}). Check your key at build.nvidia.com`,
+        );
+      }
+
+      return {
+        access: key,
+        refresh: key, // API keys don't have refresh tokens
+        expires: Date.now() + 365 * 24 * 60 * 60 * 1000, // effectively never
+      };
+    },
+
+    async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+      // Nvidia API keys don't expire — return as-is with extended expiry
+      return {
+        ...credentials,
+        expires: Date.now() + 365 * 24 * 60 * 60 * 1000,
+      };
+    },
+
+    getApiKey(credentials: OAuthCredentials): string {
+      return credentials.access;
+    },
+  };
 }
 
 export default function nvidiaNimExtension(pi: ExtensionAPI) {
-  // Register synchronously at init so models are available before Pi finishes loading
-  const savedConfig = loadConfigSync();
-  if (savedConfig && savedConfig.models.length > 0) {
-    registerProvider(pi, savedConfig);
-  }
+  // Load saved models synchronously at init so they're available before Pi finishes loading.
+  // The provider is always registered (even without models) so `/login nvidia` works.
+  const savedModels = loadModelsConfigSync();
+  const models = savedModels?.models ?? [];
 
-  // --- /nvidia-nim-auth: full setup (API key + models) ---
-  const authHandler = async (args: string | undefined, ctx: ExtensionCommandContext) => {
-    if (!ctx.hasUI) {
-      console.log("This command requires interactive mode.");
-      return;
-    }
+  pi.registerProvider(NVIDIA_PROVIDER_NAME, {
+    baseUrl: NVIDIA_BASE_URL,
+    api: "openai-completions",
+    models: buildModelDescriptors(models),
+    oauth: buildOAuthConfig(),
+  });
 
-    const existing = await loadConfig();
-
-    // Step 1: API Key
-    let apiKey = await ctx.ui.input(
-      "Nvidia NIM — Enter API Key",
-      existing ? "(current key saved — paste new key or press Enter to keep)" : "Paste your nvapi-... key from build.nvidia.com",
-    );
-
-    if (!apiKey?.trim() && existing?.apiKey) {
-      apiKey = existing.apiKey;
-    } else if (!apiKey?.trim()) {
-      ctx.ui.notify("Setup cancelled — API key is required.", "error");
-      return;
-    }
-
-    apiKey = apiKey.trim();
-    if (!apiKey.startsWith("nvapi-")) {
-      const proceed = await ctx.ui.confirm(
-        "Nvidia NIM — API Key Warning",
-        `Key doesn't start with "nvapi-". Nvidia NIM keys usually do.\n\nContinue anyway?`,
-      );
-      if (!proceed) return;
-    }
-
-    // Step 2: Models via multi-line editor
-    const existingModelIds = existing?.models.map((m) => m.id).join("\n") ?? "";
-    const prefill = MODEL_EDITOR_TEMPLATE + "\n" + (existingModelIds || "meta/llama-3.1-405b-instruct") + "\n";
-
-    const modelText = await ctx.ui.editor("Nvidia NIM — Edit Models (one per line)", prefill);
-
-    if (!modelText?.trim()) {
-      ctx.ui.notify("Setup cancelled — at least one model is required.", "error");
-      return;
-    }
-
-    let models = parseModelLines(modelText);
-    if (models.length === 0) {
-      ctx.ui.notify("No valid model IDs found. Add at least one non-comment line.", "error");
-      return;
-    }
-
-    // Validate model IDs against the Nvidia API
-    ctx.ui.notify("Validating model IDs against Nvidia NIM API...", "info");
-    const available = await fetchAvailableModels(apiKey);
-    if (available) {
-      const invalid = models.filter((m) => !available.has(m.id));
-      if (invalid.length > 0) {
-        const names = invalid.map((m) => m.id).join(", ");
-        const proceed = await ctx.ui.confirm(
-          "Nvidia NIM — Invalid Model IDs",
-          `These model IDs were not found on the API:\n\n  ${names}\n\nSave anyway (they'll 404), or cancel to fix them?`,
-        );
-        if (!proceed) return;
-      }
-    }
-
-    // Save + register + add to scoped models
-    const config: NvidiaNimConfig = { apiKey, models };
-    try {
-      await saveConfig(config);
-      registerProvider(pi, config);
-      await updateEnabledModels(models);
-      const names = models.map((m) => m.id).join(", ");
-      ctx.ui.notify(`Nvidia NIM configured — ${models.length} model(s): ${names}. Available in /model.`, "info");
-    } catch (error) {
-      ctx.ui.notify(`Failed to save: ${error instanceof Error ? error.message : String(error)}`, "error");
-    }
-  };
-
-  // --- /nvidia-nim-models: quick add/edit models without re-entering key ---
+  // --- /nvidia-nim-models: add/edit models ---
   const modelsHandler = async (args: string | undefined, ctx: ExtensionCommandContext) => {
     if (!ctx.hasUI) {
       console.log("This command requires interactive mode.");
       return;
     }
 
-    const existing = await loadConfig();
-    if (!existing) {
-      ctx.ui.notify("Run /nvidia-nim-auth first to set up your API key.", "error");
-      return;
-    }
-
-    const existingModelIds = existing.models.map((m) => m.id).join("\n");
-    const prefill = MODEL_EDITOR_TEMPLATE + "\n" + existingModelIds + "\n";
+    const existing = await loadModelsConfig();
+    const existingModelIds = existing?.models.map((m) => m.id).join("\n") ?? "";
+    const prefill =
+      MODEL_EDITOR_TEMPLATE + "\n" + (existingModelIds || "meta/llama-3.1-405b-instruct") + "\n";
 
     const modelText = await ctx.ui.editor("Nvidia NIM — Edit Models (one per line)", prefill);
     if (!modelText?.trim()) {
@@ -277,32 +213,35 @@ export default function nvidiaNimExtension(pi: ExtensionAPI) {
       return;
     }
 
-    const models = parseModelLines(modelText);
-    if (models.length === 0) {
+    const parsedModels = parseModelLines(modelText);
+    if (parsedModels.length === 0) {
       ctx.ui.notify("No valid model IDs found. Models unchanged.", "error");
       return;
     }
 
-    const config: NvidiaNimConfig = { apiKey: existing.apiKey, models };
     try {
-      await saveConfig(config);
-      registerProvider(pi, config);
-      await updateEnabledModels(models);
-      ctx.ui.notify(`Nvidia NIM models updated — ${models.length} model(s). Available in /model.`, "info");
+      await saveModelsConfig({ models: parsedModels });
+
+      // Re-register provider with updated models (preserving OAuth config)
+      pi.registerProvider(NVIDIA_PROVIDER_NAME, {
+        baseUrl: NVIDIA_BASE_URL,
+        api: "openai-completions",
+        models: buildModelDescriptors(parsedModels),
+        oauth: buildOAuthConfig(),
+      });
+
+      const names = parsedModels.map((m) => m.id).join(", ");
+      ctx.ui.notify(
+        `Nvidia NIM models updated — ${parsedModels.length} model(s): ${names}. Use /login nvidia to authenticate.`,
+        "info",
+      );
     } catch (error) {
-      ctx.ui.notify(`Failed to save: ${error instanceof Error ? error.message : String(error)}`, "error");
+      ctx.ui.notify(
+        `Failed to save: ${error instanceof Error ? error.message : String(error)}`,
+        "error",
+      );
     }
   };
-
-  pi.registerCommand("nvidia-nim-auth", {
-    description: "Configure Nvidia NIM API key and models",
-    handler: authHandler,
-  });
-
-  pi.registerCommand("nvidia-auth", {
-    description: "Configure Nvidia NIM (alias for /nvidia-nim-auth)",
-    handler: authHandler,
-  });
 
   pi.registerCommand("nvidia-nim-models", {
     description: "Add or edit Nvidia NIM models",


### PR DESCRIPTION
Replace custom /nvidia-nim-auth and /nvidia-auth commands with Pi's built-in OAuth system via /login nvidia. API key credentials are now managed in ~/.pi/agent/auth.json instead of a custom config file.

Remove manual updateEnabledModels() — registerProvider() with models handles visibility natively. Keep /nvidia-nim-models for model list management. Config file now stores models only, with backward compatibility for legacy format containing apiKey.