### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in session identifiers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - [CRITICAL] Incomplete Path Traversal Prevention
+**Vulnerability:** The session control extension validated `sessionId` and `alias` using `!includes("/")`, `!includes("\\")`, and `!includes("..")`. This blacklist approach is incomplete and susceptible to path traversal via bypasses or control characters.
+**Learning:** Naive string inclusion checks are insufficient for validating file identifiers and protecting against path traversal in file system operations.
+**Prevention:** Always use strict regex allowlists (e.g., `/^[a-zA-Z0-9_-]+$/` and `/^[a-zA-Z0-9_ -]+$/`) when validating user-provided identifiers before interpolating them into paths.

--- a/extensions/control/index.ts
+++ b/extensions/control/index.ts
@@ -189,11 +189,11 @@ function getSocketPath(sessionId: string): string {
 }
 
 function isSafeSessionId(sessionId: string): boolean {
-	return !sessionId.includes("/") && !sessionId.includes("\\") && !sessionId.includes("..") && sessionId.length > 0;
+	return /^[a-zA-Z0-9_-]+$/.test(sessionId);
 }
 
 function isSafeAlias(alias: string): boolean {
-	return !alias.includes("/") && !alias.includes("\\") && !alias.includes("..") && alias.length > 0;
+	return /^[a-zA-Z0-9_ -]+$/.test(alias);
 }
 
 function getAliasPath(alias: string): string {


### PR DESCRIPTION
Fixes a path traversal vulnerability in `extensions/control/index.ts` where `sessionId` and `alias` were validated using insufficient string blacklist checks.

---
*PR created automatically by Jules for task [7659451937259293879](https://jules.google.com/task/7659451937259293879) started by @jayshah5696*