### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in temporary files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Secure Temporary File Creation
+**Vulnerability:** Information Disclosure
+**Learning:** Temporary files created in shared directories like `os.tmpdir()` with default permissions can be world-readable, exposing sensitive data to other users on the system.
+**Prevention:** Always explicitly set secure file permissions (e.g., `{ mode: 0o600 }`) when creating temporary files using functions like `writeFileSync`.

--- a/extensions/files/index.ts
+++ b/extensions/files/index.ts
@@ -697,7 +697,7 @@ const openExternalEditor = (tui: TUI, editorCmd: string, content: string): strin
 	const tmpFile = path.join(os.tmpdir(), `pi-files-edit-${crypto.randomBytes(16).toString("hex")}.txt`);
 
 	try {
-		writeFileSync(tmpFile, content, "utf8");
+		writeFileSync(tmpFile, content, { encoding: "utf8", mode: 0o600 });
 		tui.stop();
 
 		const [editor, ...editorArgs] = editorCmd.split(" ");
@@ -814,15 +814,15 @@ const openDiff = async (pi: ExtensionAPI, ctx: ExtensionContext, target: FileEnt
 			ctx.ui.notify(errorMessage, "error");
 			return;
 		}
-		writeFileSync(tmpFile, result.stdout ?? "", "utf8");
+		writeFileSync(tmpFile, result.stdout ?? "", { encoding: "utf8", mode: 0o600 });
 	} else {
-		writeFileSync(tmpFile, "", "utf8");
+		writeFileSync(tmpFile, "", { encoding: "utf8", mode: 0o600 });
 	}
 
 	let workingPath = target.resolvedPath;
 	if (!existsSync(target.resolvedPath)) {
 		workingPath = path.join(tmpDir, `pi-files-working-${path.basename(target.displayPath)}`);
-		writeFileSync(workingPath, "", "utf8");
+		writeFileSync(workingPath, "", { encoding: "utf8", mode: 0o600 });
 	}
 
 	const openResult = await pi.exec("code", ["--diff", tmpFile, workingPath], { cwd: gitRoot });


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in temporary files

🚨 Severity: MEDIUM
💡 Vulnerability: The `files` extension wrote sensitive file contents (like code being edited or diffed) into temporary files in `os.tmpdir()` using `writeFileSync` without explicit permissions. This meant the files were created with default system permissions (often `0o644`), making them world-readable to other users on the system.
🎯 Impact: Local information disclosure. On a multi-user machine, another user could read the contents of files currently being edited or reviewed by the developer.
🔧 Fix: Updated all `writeFileSync` calls creating temporary files in `extensions/files/index.ts` to explicitly set `{ encoding: "utf8", mode: 0o600 }`. This ensures only the user executing the program can read and write the files.
✅ Verification: Ran the `files` test suite using `npm run test`, which passed fully.

---
*PR created automatically by Jules for task [15510040381560766881](https://jules.google.com/task/15510040381560766881) started by @jayshah5696*