### PR TITLE
🛡️ Sentinel: [HIGH] Fix information disclosure in shared temporary directories

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Information Disclosure in Shared Temporary Directories]
+**Vulnerability:** Temporary files created in shared directories (like `os.tmpdir()`) without explicit permissions could be read or modified by other local users on the system.
+**Learning:** `writeFileSync` defaults to the standard umask if not provided. In multi-user environments, this can lead to sensitive information leakage.
+**Prevention:** Always explicitly set secure file permissions (e.g., `{ encoding: "utf8", mode: 0o600 }`) when creating temporary files in shared directories using functions like `writeFileSync`.

--- a/extensions/files/index.ts
+++ b/extensions/files/index.ts
@@ -697,7 +697,7 @@ const openExternalEditor = (tui: TUI, editorCmd: string, content: string): strin
 	const tmpFile = path.join(os.tmpdir(), `pi-files-edit-${crypto.randomBytes(16).toString("hex")}.txt`);
 
 	try {
-		writeFileSync(tmpFile, content, "utf8");
+		writeFileSync(tmpFile, content, { encoding: "utf8", mode: 0o600 });
 		tui.stop();
 
 		const [editor, ...editorArgs] = editorCmd.split(" ");
@@ -814,15 +814,15 @@ const openDiff = async (pi: ExtensionAPI, ctx: ExtensionContext, target: FileEnt
 			ctx.ui.notify(errorMessage, "error");
 			return;
 		}
-		writeFileSync(tmpFile, result.stdout ?? "", "utf8");
+		writeFileSync(tmpFile, result.stdout ?? "", { encoding: "utf8", mode: 0o600 });
 	} else {
-		writeFileSync(tmpFile, "", "utf8");
+		writeFileSync(tmpFile, "", { encoding: "utf8", mode: 0o600 });
 	}
 
 	let workingPath = target.resolvedPath;
 	if (!existsSync(target.resolvedPath)) {
 		workingPath = path.join(tmpDir, `pi-files-working-${path.basename(target.displayPath)}`);
-		writeFileSync(workingPath, "", "utf8");
+		writeFileSync(workingPath, "", { encoding: "utf8", mode: 0o600 });
 	}
 
 	const openResult = await pi.exec("code", ["--diff", tmpFile, workingPath], { cwd: gitRoot });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Temporary files created in shared directories (like `os.tmpdir()`) without explicit permissions could be read or modified by other local users on the system.
🎯 Impact: This could lead to sensitive information leakage or tampering by unauthorized local users.
🔧 Fix: Updated `writeFileSync` calls in `extensions/files/index.ts` to explicitly set file permissions using `{ encoding: "utf8", mode: 0o600 }` (read/write only by the owner).
✅ Verification: Ran `npm test` successfully. Verified that `writeFileSync` calls explicitly include `mode: 0o600`.

---
*PR created automatically by Jules for task [5680414940739933772](https://jules.google.com/task/5680414940739933772) started by @jayshah5696*