### PR TITLE
🛡️ Sentinel: [HIGH] Fix information disclosure in temporary files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - Prevent Information Disclosure in Temporary Files
+**Vulnerability:** Temporary files created using `writeFileSync` with just an encoding string (e.g., `"utf8"`) or default permissions in shared directories like `os.tmpdir()` can be read or modified by other users on the system, leading to local information disclosure or tampering.
+**Learning:** Node.js file creation functions use the process's `umask` by default, which is often overly permissive (like `0o644` or `0o666`) for temporary files holding potentially sensitive data (like source code edits or diffs). We must explicitly set restrictive permissions.
+**Prevention:** To prevent information disclosure vulnerabilities, always explicitly set secure file permissions (e.g., `{ mode: 0o600 }`) when creating temporary files in shared directories like `os.tmpdir()` using functions like `writeFileSync`.

--- a/extensions/files/index.ts
+++ b/extensions/files/index.ts
@@ -697,7 +697,7 @@ const openExternalEditor = (tui: TUI, editorCmd: string, content: string): strin
 	const tmpFile = path.join(os.tmpdir(), `pi-files-edit-${crypto.randomBytes(16).toString("hex")}.txt`);
 
 	try {
-		writeFileSync(tmpFile, content, "utf8");
+		writeFileSync(tmpFile, content, { encoding: "utf8", mode: 0o600 });
 		tui.stop();
 
 		const [editor, ...editorArgs] = editorCmd.split(" ");
@@ -814,15 +814,15 @@ const openDiff = async (pi: ExtensionAPI, ctx: ExtensionContext, target: FileEnt
 			ctx.ui.notify(errorMessage, "error");
 			return;
 		}
-		writeFileSync(tmpFile, result.stdout ?? "", "utf8");
+		writeFileSync(tmpFile, result.stdout ?? "", { encoding: "utf8", mode: 0o600 });
 	} else {
-		writeFileSync(tmpFile, "", "utf8");
+		writeFileSync(tmpFile, "", { encoding: "utf8", mode: 0o600 });
 	}
 
 	let workingPath = target.resolvedPath;
 	if (!existsSync(target.resolvedPath)) {
 		workingPath = path.join(tmpDir, `pi-files-working-${path.basename(target.displayPath)}`);
-		writeFileSync(workingPath, "", "utf8");
+		writeFileSync(workingPath, "", { encoding: "utf8", mode: 0o600 });
 	}
 
 	const openResult = await pi.exec("code", ["--diff", tmpFile, workingPath], { cwd: gitRoot });


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** When editing or diffing a file with `/files`, temporary copies containing potentially sensitive code edits or repository diffs are written to `os.tmpdir()` (`/tmp` on Unix) without explicitly restricted file permissions. Relying on default `umask` can inadvertently make these files readable/writable to other users on the system.
🎯 **Impact:** In multi-tenant environments or shared machines, an attacker could monitor the temporary directory, and potentially read proprietary source code, credentials present in the active file, or alter diff comparisons. 
🔧 **Fix:** Passed `{ encoding: "utf8", mode: 0o600 }` to all relevant `writeFileSync` invocations for temporary files inside `extensions/files/index.ts`, ensuring read/write access is tightly scoped to only the current user. Also added an entry logging this codebase-specific vulnerability pattern in `.jules/sentinel.md` for future reference.
✅ **Verification:** Verified by checking that automated node:test suites successfully run post-installation of `tsx`. File read/write logic functions the same, but files are now properly secured against external access attempts.

---
*PR created automatically by Jules for task [10867746757253325241](https://jules.google.com/task/10867746757253325241) started by @jayshah5696*