### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions in todos extension

### DIFF
--- a/extensions/todos/index.ts
+++ b/extensions/todos/index.ts
@@ -923,7 +923,7 @@ async function readTodoFile(filePath: string, idFallback: string): Promise<TodoR
 }
 
 async function writeTodoFile(filePath: string, todo: TodoRecord) {
-	await fs.writeFile(filePath, serializeTodo(todo), "utf8");
+	await fs.writeFile(filePath, serializeTodo(todo), { encoding: "utf8", mode: 0o600 });
 }
 
 async function generateTodoId(todosDir: string): Promise<string> {
@@ -955,7 +955,7 @@ async function acquireLock(
 
 	for (let attempt = 0; attempt < 2; attempt += 1) {
 		try {
-			const handle = await fs.open(lockPath, "wx");
+			const handle = await fs.open(lockPath, "wx", 0o600);
 			const info: LockInfo = {
 				id,
 				pid: process.pid,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: When creating local files (`.pi/todos/*.md` and `*.lock`), standard process UMASK is used, making user data and state accessible to other local users.
🎯 Impact: Local users on a shared workstation or server could read or modify a user's local tasks.
🔧 Fix: Added explicit mode `0o600` (read/write by owner only) to both `fs.writeFile` (for the actual todo files) and `fs.open` (for lock files) inside `extensions/todos/index.ts`.
✅ Verification: `npm test` passes completely.

---
*PR created automatically by Jules for task [425356614703101876](https://jules.google.com/task/425356614703101876) started by @jayshah5696*