### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce secure file modes on configurations and lockfiles

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Temporary files created using `writeFileSync` with just an encoding string (e.g., `"utf8"`) or default permissions in shared directories like `os.tmpdir()` can be read or modified by other users on the system, leading to local information disclosure or tampering.
 **Learning:** Node.js file creation functions use the process's `umask` by default, which is often overly permissive (like `0o644` or `0o666`) for temporary files holding potentially sensitive data (like source code edits or diffs). We must explicitly set restrictive permissions.
 **Prevention:** To prevent information disclosure vulnerabilities, always explicitly set secure file permissions (e.g., `{ mode: 0o600 }`) when creating temporary files in shared directories like `os.tmpdir()` using functions like `writeFileSync`.
+## 2026-04-02 - Secure Lockfiles and Configuration Files
+**Vulnerability:** Lockfiles and configuration files (like `.pi/todos/*.lock` and `.pi/agent/settings.json`) created without explicit file modes could inherit permissive umask defaults.
+**Learning:** The memory constraints learned for temporary files must also be strictly applied to local state, persistent lockfiles, and configuration files, to prevent any local privilege escalation or sensitive information disclosure to other system users.
+**Prevention:** Pass explicit mode flags (e.g. `0o600`) when using `fs.open`, `fs.writeFile` and `fs.promises.writeFile` for config and lock paths.

--- a/extensions/nvidia-nim/index.ts
+++ b/extensions/nvidia-nim/index.ts
@@ -69,7 +69,7 @@ export function loadModelsConfigSync(): NvidiaModelsConfig | null {
 export async function saveModelsConfig(config: NvidiaModelsConfig): Promise<void> {
   const configPath = getConfigPath();
   await fs.mkdir(path.dirname(configPath), { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 /** Parse model IDs from editor text, ignoring comments and blank lines.

--- a/extensions/todos/index.ts
+++ b/extensions/todos/index.ts
@@ -955,7 +955,7 @@ async function acquireLock(
 
 	for (let attempt = 0; attempt < 2; attempt += 1) {
 		try {
-			const handle = await fs.open(lockPath, "wx");
+			const handle = await fs.open(lockPath, "wx", 0o600);
 			const info: LockInfo = {
 				id,
 				pid: process.pid,

--- a/extensions/whimsical/index.ts
+++ b/extensions/whimsical/index.ts
@@ -263,7 +263,7 @@ async function saveStateToSettings(): Promise<void> {
   } satisfies PersistedWhimsyConfig;
 
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(settingsPath, JSON.stringify(parsed, null, 2), "utf-8");
+  await fs.writeFile(settingsPath, JSON.stringify(parsed, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 async function ensureStateLoaded(): Promise<void> {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Configuration files and lockfiles created by `fs.writeFile` and `fs.open` were relying on the environment's `umask`, which could allow other users on the local machine to read or modify the agent's internal state.
🎯 Impact: This could lead to information disclosure or localized privilege escalation depending on the contents of the configuration, especially for API integrations like Nvidia NIM.
🔧 Fix: Explicitly enforced a file mode of `0o600` on the `fs.open` and `fs.writeFile` calls creating these files.
✅ Verification: Ran `npm run test` which completed successfully with 160 passes.

---
*PR created automatically by Jules for task [9946270212347971749](https://jules.google.com/task/9946270212347971749) started by @jayshah5696*