### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions in nvidia-nim configuration

### DIFF
--- a/extensions/nvidia-nim/index.ts
+++ b/extensions/nvidia-nim/index.ts
@@ -69,7 +69,7 @@ export function loadModelsConfigSync(): NvidiaModelsConfig | null {
 export async function saveModelsConfig(config: NvidiaModelsConfig): Promise<void> {
   const configPath = getConfigPath();
   await fs.mkdir(path.dirname(configPath), { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 /** Parse model IDs from editor text, ignoring comments and blank lines.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `nvidia-nim.json` configuration file was being saved without explicit permissions, meaning it defaulted to the system umask (often `0o644` or `0o666`). This could expose potentially sensitive models or configurations to other users on the system.
🎯 Impact: Local information disclosure or unauthorized tampering of user agent settings.
🔧 Fix: Updated `fs.writeFile` in `extensions/nvidia-nim/index.ts` to use `{ encoding: "utf-8", mode: 0o600 }` instead of the `"utf-8"` string shorthand, ensuring only the owner can read/write the file.
✅ Verification: Ran `npm test` successfully. Can be verified by running the `nvidia-nim-models` extension command and checking `ls -la ~/.pi/nvidia-nim.json` to ensure permissions are `-rw-------`.

---
*PR created automatically by Jules for task [18113718069518259538](https://jules.google.com/task/18113718069518259538) started by @jayshah5696*