### PR TITLE
🛡️ Sentinel: Enforce secure file permissions

### DIFF
--- a/extensions/ask-user/modes/print.ts
+++ b/extensions/ask-user/modes/print.ts
@@ -40,7 +40,7 @@ export async function createPendingFile(params: AskUserParams, ctx: ExtensionCon
   };
 
   // Write file
-  await writeFile(pendingFile, JSON.stringify(pending, null, 2), "utf-8");
+  await writeFile(pendingFile, JSON.stringify(pending, null, 2), { encoding: "utf-8", mode: 0o600 });
 
   return pendingFile;
 }

--- a/extensions/files/index.ts
+++ b/extensions/files/index.ts
@@ -742,7 +742,7 @@ const editPath = async (ctx: ExtensionContext, target: FileEntry, content: strin
 	}
 
 	try {
-		writeFileSync(target.resolvedPath, updated, "utf8");
+		writeFileSync(target.resolvedPath, updated, { encoding: "utf8", mode: 0o600 });
 	} catch {
 		ctx.ui.notify(`Failed to save ${target.displayPath}`, "error");
 	}

--- a/extensions/nvidia-nim/index.ts
+++ b/extensions/nvidia-nim/index.ts
@@ -69,7 +69,7 @@ export function loadModelsConfigSync(): NvidiaModelsConfig | null {
 export async function saveModelsConfig(config: NvidiaModelsConfig): Promise<void> {
   const configPath = getConfigPath();
   await fs.mkdir(path.dirname(configPath), { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 /** Parse model IDs from editor text, ignoring comments and blank lines.

--- a/extensions/todos/index.ts
+++ b/extensions/todos/index.ts
@@ -923,7 +923,7 @@ async function readTodoFile(filePath: string, idFallback: string): Promise<TodoR
 }
 
 async function writeTodoFile(filePath: string, todo: TodoRecord) {
-	await fs.writeFile(filePath, serializeTodo(todo), "utf8");
+	await fs.writeFile(filePath, serializeTodo(todo), { encoding: "utf8", mode: 0o600 });
 }
 
 async function generateTodoId(todosDir: string): Promise<string> {
@@ -962,7 +962,7 @@ async function acquireLock(
 				session,
 				created_at: new Date(now).toISOString(),
 			};
-			await handle.writeFile(JSON.stringify(info, null, 2), "utf8");
+			await handle.writeFile(JSON.stringify(info, null, 2), { encoding: "utf8", mode: 0o600 });
 			await handle.close();
 			return async () => {
 				try {


### PR DESCRIPTION
🚨 Severity: LOW / ENHANCEMENT
💡 Vulnerability: Node file creation functions use default permissions (usually 0o666 or 0o644 based on umask), which can leave sensitive temporary files and configuration open to reading by other local users.
🎯 Impact: Minor information disclosure if running on a shared host.
🔧 Fix: Added explicit `{ mode: 0o600 }` to `writeFile` and `writeFileSync` calls across multiple extensions (Nvidia NIM config, Todos, Files, Ask User) so only the owner has read/write access.
✅ Verification: Tests pass and changes adhere to explicit mode specifications.

---
*PR created automatically by Jules for task [4284400645955559169](https://jules.google.com/task/4284400645955559169) started by @jayshah5696*