### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions

### DIFF
--- a/extensions/nvidia-nim/index.ts
+++ b/extensions/nvidia-nim/index.ts
@@ -69,7 +69,7 @@ export function loadModelsConfigSync(): NvidiaModelsConfig | null {
 export async function saveModelsConfig(config: NvidiaModelsConfig): Promise<void> {
   const configPath = getConfigPath();
   await fs.mkdir(path.dirname(configPath), { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 /** Parse model IDs from editor text, ignoring comments and blank lines.

--- a/extensions/todos/index.ts
+++ b/extensions/todos/index.ts
@@ -923,7 +923,7 @@ async function readTodoFile(filePath: string, idFallback: string): Promise<TodoR
 }
 
 async function writeTodoFile(filePath: string, todo: TodoRecord) {
-	await fs.writeFile(filePath, serializeTodo(todo), "utf8");
+	await fs.writeFile(filePath, serializeTodo(todo), { encoding: "utf8", mode: 0o600 });
 }
 
 async function generateTodoId(todosDir: string): Promise<string> {
@@ -955,7 +955,7 @@ async function acquireLock(
 
 	for (let attempt = 0; attempt < 2; attempt += 1) {
 		try {
-			const handle = await fs.open(lockPath, "wx");
+			const handle = await fs.open(lockPath, "wx", 0o600);
 			const info: LockInfo = {
 				id,
 				pid: process.pid,

--- a/extensions/whimsical/index.ts
+++ b/extensions/whimsical/index.ts
@@ -263,7 +263,7 @@ async function saveStateToSettings(): Promise<void> {
   } satisfies PersistedWhimsyConfig;
 
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(settingsPath, JSON.stringify(parsed, null, 2), "utf-8");
+  await fs.writeFile(settingsPath, JSON.stringify(parsed, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 async function ensureStateLoaded(): Promise<void> {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Temporary files, user configurations, and state lockfiles were being created without explicit file permissions. In shared directories or sensitive home directories, this could lead to local information disclosure or tampering by other users.
🎯 **Impact:** Other users on the system could potentially read sensitive API models/configurations or tamper with lockfiles and todos.
🔧 **Fix:** Added explicit secure file permissions `{ mode: 0o600 }` to `fs.writeFile` and `fs.open` calls in `extensions/nvidia-nim/index.ts`, `extensions/todos/index.ts`, and `extensions/whimsical/index.ts`.
✅ **Verification:** Verify that files created by these extensions (e.g. `~/.pi/nvidia-nim.json`, `.pi/todos/*.md`, `~/.pi/agent/settings.json`) now have `0o600` permissions. Tests were also run to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [7439359632671184637](https://jules.google.com/task/7439359632671184637) started by @jayshah5696*