### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions on config/state files

### DIFF
--- a/extensions/ask-user/modes/print.ts
+++ b/extensions/ask-user/modes/print.ts
@@ -40,7 +40,7 @@ export async function createPendingFile(params: AskUserParams, ctx: ExtensionCon
   };
 
   // Write file
-  await writeFile(pendingFile, JSON.stringify(pending, null, 2), "utf-8");
+  await writeFile(pendingFile, JSON.stringify(pending, null, 2), { encoding: "utf-8", mode: 0o600 });
 
   return pendingFile;
 }

--- a/extensions/nvidia-nim/index.ts
+++ b/extensions/nvidia-nim/index.ts
@@ -69,7 +69,7 @@ export function loadModelsConfigSync(): NvidiaModelsConfig | null {
 export async function saveModelsConfig(config: NvidiaModelsConfig): Promise<void> {
   const configPath = getConfigPath();
   await fs.mkdir(path.dirname(configPath), { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 /** Parse model IDs from editor text, ignoring comments and blank lines.

--- a/extensions/todos/index.ts
+++ b/extensions/todos/index.ts
@@ -923,7 +923,7 @@ async function readTodoFile(filePath: string, idFallback: string): Promise<TodoR
 }
 
 async function writeTodoFile(filePath: string, todo: TodoRecord) {
-	await fs.writeFile(filePath, serializeTodo(todo), "utf8");
+	await fs.writeFile(filePath, serializeTodo(todo), { encoding: "utf8", mode: 0o600 });
 }
 
 async function generateTodoId(todosDir: string): Promise<string> {
@@ -955,14 +955,14 @@ async function acquireLock(
 
 	for (let attempt = 0; attempt < 2; attempt += 1) {
 		try {
-			const handle = await fs.open(lockPath, "wx");
+			const handle = await fs.open(lockPath, "wx", 0o600);
 			const info: LockInfo = {
 				id,
 				pid: process.pid,
 				session,
 				created_at: new Date(now).toISOString(),
 			};
-			await handle.writeFile(JSON.stringify(info, null, 2), "utf8");
+			await handle.writeFile(JSON.stringify(info, null, 2), { encoding: "utf8" });
 			await handle.close();
 			return async () => {
 				try {

--- a/extensions/whimsical/index.ts
+++ b/extensions/whimsical/index.ts
@@ -263,7 +263,7 @@ async function saveStateToSettings(): Promise<void> {
   } satisfies PersistedWhimsyConfig;
 
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(settingsPath, JSON.stringify(parsed, null, 2), "utf-8");
+  await fs.writeFile(settingsPath, JSON.stringify(parsed, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 async function ensureStateLoaded(): Promise<void> {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Insecure file permissions for locally created config, lock, and state files. By default, `fs.writeFile` and `fs.open` use the process's current `umask` (often `0o644` or `0o666`), potentially allowing other system users to read sensitive data stored in `.pi` config directories.
🎯 Impact: Unauthorized local users could potentially view or tamper with AI prompts, task context, configurations (like `nvidia-nim.json`), or lockfiles, causing data exposure or denial of service on local shared machines.
🔧 Fix: Explicitly added `{ mode: 0o600 }` to `fs.writeFile` and `0o600` to `fs.open` operations in `nvidia-nim`, `ask-user`, `whimsical`, and `todos` extensions to ensure only the file owner has read/write access.
✅ Verification: Ran `npm test` successfully; visually verified codebase using regex `grep "writeFile("` that proper modes were included.

---
*PR created automatically by Jules for task [9594856900061670660](https://jules.google.com/task/9594856900061670660) started by @jayshah5696*