### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information disclosure in temporary state files

### DIFF
--- a/extensions/ask-user/modes/print.ts
+++ b/extensions/ask-user/modes/print.ts
@@ -40,7 +40,7 @@ export async function createPendingFile(params: AskUserParams, ctx: ExtensionCon
   };
 
   // Write file
-  await writeFile(pendingFile, JSON.stringify(pending, null, 2), "utf-8");
+  await writeFile(pendingFile, JSON.stringify(pending, null, 2), { encoding: "utf-8", mode: 0o600 });
 
   return pendingFile;
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential Information Disclosure. Creating temporary application state files using `fs/promises.writeFile` with default permissions (`0o644` or `0o666` depending on the system's `umask`) could allow other users on the system to read or modify the contents of `pending-questions.json`.
🎯 Impact: Local attackers could potentially read sensitive data included in `AskUserParams` prompts or tamper with pending application state.
🔧 Fix: Added explicit file permission `{ mode: 0o600 }` to `writeFile` in `extensions/ask-user/modes/print.ts` to guarantee that only the file owner can read and write the file.
✅ Verification: Ran the test suite successfully and ensured that tests pass without regressions.

---
*PR created automatically by Jules for task [16176664977319037271](https://jules.google.com/task/16176664977319037271) started by @jayshah5696*