### PR TITLE
🛡️ Sentinel: [security improvement] Secure file permissions

### DIFF
--- a/extensions/ask-user/modes/print.ts
+++ b/extensions/ask-user/modes/print.ts
@@ -40,7 +40,7 @@ export async function createPendingFile(params: AskUserParams, ctx: ExtensionCon
   };
 
   // Write file
-  await writeFile(pendingFile, JSON.stringify(pending, null, 2), "utf-8");
+  await writeFile(pendingFile, JSON.stringify(pending, null, 2), { encoding: "utf-8", mode: 0o600 });
 
   return pendingFile;
 }

--- a/extensions/nvidia-nim/index.ts
+++ b/extensions/nvidia-nim/index.ts
@@ -69,7 +69,7 @@ export function loadModelsConfigSync(): NvidiaModelsConfig | null {
 export async function saveModelsConfig(config: NvidiaModelsConfig): Promise<void> {
   const configPath = getConfigPath();
   await fs.mkdir(path.dirname(configPath), { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 /** Parse model IDs from editor text, ignoring comments and blank lines.

--- a/extensions/todos/index.ts
+++ b/extensions/todos/index.ts
@@ -923,7 +923,7 @@ async function readTodoFile(filePath: string, idFallback: string): Promise<TodoR
 }
 
 async function writeTodoFile(filePath: string, todo: TodoRecord) {
-	await fs.writeFile(filePath, serializeTodo(todo), "utf8");
+	await fs.writeFile(filePath, serializeTodo(todo), { encoding: "utf8", mode: 0o600 });
 }
 
 async function generateTodoId(todosDir: string): Promise<string> {
@@ -955,14 +955,14 @@ async function acquireLock(
 
 	for (let attempt = 0; attempt < 2; attempt += 1) {
 		try {
-			const handle = await fs.open(lockPath, "wx");
+			const handle = await fs.open(lockPath, "wx", 0o600);
 			const info: LockInfo = {
 				id,
 				pid: process.pid,
 				session,
 				created_at: new Date(now).toISOString(),
 			};
-			await handle.writeFile(JSON.stringify(info, null, 2), "utf8");
+			await handle.writeFile(JSON.stringify(info, null, 2), { encoding: "utf8", mode: 0o600 });
 			await handle.close();
 			return async () => {
 				try {

--- a/extensions/whimsical/index.ts
+++ b/extensions/whimsical/index.ts
@@ -263,7 +263,7 @@ async function saveStateToSettings(): Promise<void> {
   } satisfies PersistedWhimsyConfig;
 
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(settingsPath, JSON.stringify(parsed, null, 2), "utf-8");
+  await fs.writeFile(settingsPath, JSON.stringify(parsed, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 async function ensureStateLoaded(): Promise<void> {


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Information Disclosure (Insecure File Permissions). When creating files using `fs.writeFile`, the default system `umask` dictates the permissions. On many systems, this creates files readable by other local users (e.g., `0o644` or `0o666`).
🎯 **Impact**: Malicious local actors on the same machine could read sensitive configuration settings (like `.pi/nvidia-nim.json` models setup, `ask-user` state, or `.pi/todos` logs).
🔧 **Fix**: Enforced principle of least privilege by explicitly defining `{ encoding: 'utf-8', mode: 0o600 }` on configuration, locking, and temporary files across `ask-user`, `nvidia-nim`, `todos`, and `whimsical` extensions.
✅ **Verification**: Code review verified all usages of `fs.writeFile` in target extensions enforce strict permissions. `npm test` successfully completed with 160 passing tests.

---
*PR created automatically by Jules for task [15447511025098675467](https://jules.google.com/task/15447511025098675467) started by @jayshah5696*