### PR TITLE
Fix path traversal in control extension (allowlist regex)

### DIFF
--- a/extensions/control/index.ts
+++ b/extensions/control/index.ts
@@ -189,11 +189,11 @@ function getSocketPath(sessionId: string): string {
 }
 
 function isSafeSessionId(sessionId: string): boolean {
-	return !sessionId.includes("/") && !sessionId.includes("\\") && !sessionId.includes("..") && sessionId.length > 0;
+	return /^[a-zA-Z0-9_-]+$/.test(sessionId);
 }
 
 function isSafeAlias(alias: string): boolean {
-	return !alias.includes("/") && !alias.includes("\\") && !alias.includes("..") && alias.length > 0;
+	return /^[a-zA-Z0-9_ -]+$/.test(alias);
 }
 
 function getAliasPath(alias: string): string {


### PR DESCRIPTION
Replaces blacklist path validation (.includes checks) with strict allowlist regex for sessionId and alias validation. Supersedes #8 which had merge conflicts.

- `isSafeSessionId`: `/^[a-zA-Z0-9_-]+$/`
- `isSafeAlias`: `/^[a-zA-Z0-9_ -]+$/`