### PR TITLE
feat: add workflow control plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Added release helper scripts and `just` recipes for repeatable npm publishing (`release:check`, `release:publish`, `just release patch`, etc.).
 - Added the `/workflow` dynamic-workflow extension with Lean/Balanced/Deep/Custom model profiles, scoped searchable model routing, generated-script approval, tolerant generated-script normalization, trusted-project enforcement, background execution, saved JavaScript workflows, durable history, and journaled pause/resume.
 - Added a unified interactive workflow run browser with rendered results, phase and agent drill-down, visible token/cost usage, prompt and recent tool-activity capture, Markdown/visual-HTML exports, reusable-script saving, and live pause/resume/stop controls.
+- Added `/workflow help` as an in-Pi quick-start and operations guide, plus a read-only `/workflow doctor` readiness check that makes no model calls.
 
 ### Fixed
 - Workflow approval now opens on the complete line-numbered JavaScript, requires an explicit `y`, and keeps route/security details on a separate summary tab.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Added release helper scripts and `just` recipes for repeatable npm publishing (`release:check`, `release:publish`, `just release patch`, etc.).
-- Added the `/workflow` dynamic-workflow extension with Lean/Balanced/Deep/Custom model profiles, semantic role routing, generated-script approval, trusted-project enforcement, background execution, saved JavaScript workflows, durable history, and journaled pause/resume.
+- Added the `/workflow` dynamic-workflow extension with Lean/Balanced/Deep/Custom model profiles, scoped searchable model routing, generated-script approval, tolerant generated-script normalization, trusted-project enforcement, background execution, saved JavaScript workflows, durable history, and journaled pause/resume.
 
 ## [0.4.4] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project will be documented in this file.
 - Added the `/workflow` dynamic-workflow extension with Lean/Balanced/Deep/Custom model profiles, scoped searchable model routing, generated-script approval, tolerant generated-script normalization, trusted-project enforcement, background execution, saved JavaScript workflows, durable history, and journaled pause/resume.
 - Added a unified interactive workflow run browser with rendered results, phase and agent drill-down, visible token/cost usage, prompt and recent tool-activity capture, Markdown/visual-HTML exports, reusable-script saving, and live pause/resume/stop controls.
 
+### Fixed
+- Workflow approval now opens on the complete line-numbered JavaScript, requires an explicit `y`, and keeps route/security details on a separate summary tab.
+- Background workflow failures no longer trigger a parent-model turn, preventing automatic retry and repeated approval loops.
+- Generated `agent(persona)(task)`, `phase(title, callback)`, plain `run()` wrappers, and trailing `run();` forms now execute and fail inside the managed workflow instead of producing zero-agent errors or crashing Pi with an orphaned rejection.
+
 ## [0.4.4] - 2026-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-18
+
 ### Added
 - Added release helper scripts and `just` recipes for repeatable npm publishing (`release:check`, `release:publish`, `just release patch`, etc.).
 - Added the `/workflow` dynamic-workflow extension with Lean/Balanced/Deep/Custom model profiles, scoped searchable model routing, generated-script approval, tolerant generated-script normalization, trusted-project enforcement, background execution, saved JavaScript workflows, durable history, and journaled pause/resume.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Added release helper scripts and `just` recipes for repeatable npm publishing (`release:check`, `release:publish`, `just release patch`, etc.).
 - Added the `/workflow` dynamic-workflow extension with Lean/Balanced/Deep/Custom model profiles, scoped searchable model routing, generated-script approval, tolerant generated-script normalization, trusted-project enforcement, background execution, saved JavaScript workflows, durable history, and journaled pause/resume.
+- Added a unified interactive workflow run browser with rendered results, phase and agent drill-down, visible token/cost usage, prompt and recent tool-activity capture, Markdown/visual-HTML exports, reusable-script saving, and live pause/resume/stop controls.
 
 ## [0.4.4] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Added release helper scripts and `just` recipes for repeatable npm publishing (`release:check`, `release:publish`, `just release patch`, etc.).
+- Added the `/workflow` dynamic-workflow extension with Lean/Balanced/Deep/Custom model profiles, semantic role routing, generated-script approval, trusted-project enforcement, background execution, saved JavaScript workflows, durable history, and journaled pause/resume.
 
 ## [0.4.4] - 2026-05-31
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Original repository: https://github.com/mitsuhiko/agent-stuff
 | **btw** | Command | Quick side questions without history | ✅ Stable |
 | **powerline-footer** | UI | Custom powerline-style footer bar | ✅ Stable |
 | **session-breakdown** | Command | Session analytics dashboard | ✅ Stable |
+| **workflow** | Tool / Command | Model-routed dynamic workflows with `/workflow` | ⚙️ Beta |
 
 ## Install
 
@@ -164,7 +165,7 @@ pi
 
 ## Documentation & Extensions Reference
 
-For in-depth explanations, options, and commands for all 16 extensions, refer to the [Extensions Reference](docs/extensions.md).
+For in-depth explanations, options, and commands for all 17 extensions, refer to the [Extensions Reference](docs/extensions.md).
 
 For installation, manual testing, and setup guides, see the [Documentation Index](docs/README.md).
 
@@ -202,4 +203,3 @@ npm run release:publish -- patch
 ## License
 
 MIT
-

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Original repository: https://github.com/mitsuhiko/agent-stuff
 pi install npm:pi-agent-extensions
 ```
 
+The published npm package is the unscoped package [`pi-agent-extensions`](https://www.npmjs.com/package/pi-agent-extensions), so no `@scope/` prefix is needed.
+
 All extensions will be available immediately after installation.
 
 ### From Source (For Development)
@@ -109,16 +111,16 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ```bash
 # Update to latest version
-pi update pi-agent-extensions
+pi update npm:pi-agent-extensions
 
 # Or update all packages
-pi --update-packages
+pi update --extensions
 ```
 
 ## Uninstall
 
 ```bash
-pi remove pi-agent-extensions
+pi remove npm:pi-agent-extensions
 ```
 
 ## Troubleshooting

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Welcome to the documentation for **pi-agent-extensions**.
 
 ## Core Reference
 
-*   [Extensions Reference](extensions.md) — Comprehensive guide to all 16 active extensions (commands, tools, and features).
+*   [Extensions Reference](extensions.md) — Comprehensive guide to all 17 active extensions (commands, tools, and features).
 
 ## Guides
 
@@ -16,5 +16,4 @@ Setup, release, and testing guides:
 | [Publishing & Task Runner](guides/publishing.md) | Standard NPM release flow and `just` commands |
 | [Vertex AI Setup](guides/vertex-ai-setup.md) | Setting up Google Cloud Vertex AI provider for Pi |
 | [Theme Customization](../themes/CUSTOMIZATION.md) | Creating and adjusting custom terminal color themes |
-
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,6 +1,6 @@
 # Extensions Reference
 
-This document provides a comprehensive reference for the 16 extensions included in **pi-agent-extensions**.
+This document provides a comprehensive reference for the 17 extensions included in **pi-agent-extensions**.
 
 ---
 
@@ -22,6 +22,7 @@ This document provides a comprehensive reference for the 16 extensions included 
 14. [Sessions (`/sessions`)](#14-sessions-sessions)
 15. [Todos (`/todos`)](#15-todos-todos)
 16. [Whimsical (`/whimsy`)](#16-whimsical-whimsy)
+17. [Workflow (`/workflow`)](#17-workflow-workflow)
 
 ---
 
@@ -269,3 +270,61 @@ Desi/Bollywood-infused, context-aware loader spinner and exits.
     *   **Tuner Window:** Running `/whimsy` opens a percent-tuning window with interactive sliders to adjust weights and preview loader speeds.
     *   **Custom Spinners:** Options to choose spinner types: *Sleek Orbit*, *Neon Pulse*, *Scanline*, *Chevron Flow*, or *Matrix Glyph*.
     *   **Weighted Exits:** `/exit` or `/bye` commands deliver a humorous themed goodbye before closing.
+
+---
+
+## 17. Workflow (`/workflow`)
+
+Runs inspectable JavaScript orchestration programs across multiple Pi subagents, with deliberate model routing and an approval step before execution.
+
+*   **Type:** Tool & Command
+*   **Command:** `/workflow`
+*   **Tool Name:** `workflow`
+*   **Profile setup:** `/workflow setup`
+*   **Features:**
+    *   **Role-based model routing:** Configure `scout`, `worker`, `reviewer`, and `synthesizer` independently, including thinking effort.
+    *   **Profiles:** Lean (3 concurrent / 8 total), Balanced (4 / 15), Deep (6 / 40), or fully Custom.
+    *   **Approval preview:** Shows phases, scale caps, model routes, explicit model overrides, tool allowlists, and the trusted-script warning before execution.
+    *   **Background execution:** Results return to the conversation automatically while the user continues working.
+    *   **Durable runs:** Journals and results live outside the repository under `~/.pi/workflows/projects/`.
+    *   **Pause and resume:** Resuming replays the unchanged completed prefix and runs only unfinished agent calls.
+    *   **Saved workflows:** Project JavaScript in `.pi/workflows/*.js` overrides personal workflows in `~/.pi/workflows/saved/*.js`.
+    *   **Built-in workflows:** Includes `code-review`, `repository-audit`, and `migration-plan`; personal and project files can override them.
+    *   **Trust boundary:** Execution is disabled for untrusted projects. The JavaScript VM is a determinism boundary, not a security sandbox; only run scripts you trust.
+
+### Main commands
+
+```text
+/workflow run <prompt>
+/workflow saved <name> [json args]
+/workflow list
+/workflow active
+/workflow history
+/workflow status <runId>
+/workflow pause|resume|stop <runId>
+/workflow remove <runId>
+/workflow settings
+```
+
+### Saved workflow format
+
+```js
+export const meta = {
+  name: "review_change",
+  description: "Review a change from independent angles",
+  phases: [{ title: "Inspect" }, { title: "Synthesize" }],
+};
+
+phase("Inspect");
+const findings = await parallel([
+  () => agent("Review correctness and edge cases", { label: "correctness", tier: "reviewer" }),
+  () => agent("Review tests and maintainability", { label: "tests", tier: "reviewer" }),
+]);
+
+phase("Synthesize");
+const verdict = await agent(`Synthesize these findings:\n${findings.join("\n\n")}`, {
+  label: "final verdict",
+  tier: "synthesizer",
+});
+return { findings, verdict };
+```

--- a/docs/guides/manual-testing.md
+++ b/docs/guides/manual-testing.md
@@ -1,6 +1,6 @@
 # Manual Testing Guide
 
-This guide details how to manually verify the behavior of all 16 extensions and themes in a terminal session.
+This guide details how to manually verify the behavior of all 17 extensions and themes in a terminal session.
 
 ---
 
@@ -22,7 +22,7 @@ On startup, you should see:
 ```
 Extensions: sessions, ask_user, handoff, notify, context, files, review, 
             loop, answer, control, cwd-history, session-breakdown, todos, whimsical,
-            btw, powerline-footer
+            btw, powerline-footer, workflow
 ```
 
 ---
@@ -177,7 +177,26 @@ Verify the behavior of the adapted `agent-stuff` extensions:
 
 ---
 
-## 8. Color Themes
+## 8. Workflow (`/workflow`)
+
+**Goal:** Verify model-profile setup, generated-script approval, background progress, and saved workflows.
+
+### Test Instructions
+
+1. Run `/workflow setup`, choose **Balanced**, inspect the suggested role routes, and save globally.
+2. Run:
+   ```text
+   /workflow run inspect this repository for three independent maintainability risks and verify each one
+   ```
+3. Verify that the generated JavaScript approval shows phases, model roles, scale caps, tools, and the trusted-script warning.
+4. Approve it. Confirm `/workflow active` shows the background run and that its final result returns to the conversation.
+5. Add a small workflow under `.pi/workflows/smoke.js`, confirm `/workflow list` discovers it, then run `/workflow saved smoke`.
+6. Start a longer saved workflow, run `/workflow pause <runId>`, then `/workflow resume <runId>`. Confirm completed prefix agents are marked as cached rather than rerun.
+7. Decline an approval and confirm no subagent starts.
+
+---
+
+## 9. Color Themes
 
 **Goal:** Verify theme styling.
 

--- a/extensions/workflow/README.md
+++ b/extensions/workflow/README.md
@@ -1,0 +1,69 @@
+# Workflow extension
+
+`/workflow` is an opinionated dynamic-workflow control plane for Pi. It turns a decomposable request into an inspectable JavaScript program, routes subagents by semantic role, asks for approval, and runs the work in the background.
+
+Requires Pi 0.80.10 or newer.
+
+## First run
+
+```text
+/workflow setup
+/workflow run audit this repository from correctness, testing, and maintainability angles
+```
+
+Setup offers four profiles:
+
+| Profile | Concurrency | Total agents | Intent |
+|---|---:|---:|---|
+| Lean | 3 | 8 | Cheap, focused fan-out |
+| Balanced | 4 | 15 | Everyday default |
+| Deep | 6 | 40 | Larger, higher-effort investigation |
+| Custom | 1–16 | 1–1000 | Explicit routes and limits |
+
+Each profile maps four roles to an authenticated model and thinking level:
+
+* `scout` — inexpensive discovery and inventory
+* `worker` — implementation and substantial analysis
+* `reviewer` — independent criticism, preferably from another model family
+* `synthesizer` — final integration and judgment
+
+## Storage
+
+* Global control settings: `~/.pi/workflows/control-plane.json`
+* Optional project settings: `.pi/workflow.json`
+* Project workflows: `.pi/workflows/*.js`
+* Personal workflows: `~/.pi/workflows/saved/*.js`
+* Run journals and results: `~/.pi/workflows/projects/<project-hash>/runs/*.json`
+
+Project workflow files override personal files with the same filename. Run state stays outside the repository.
+
+Three built-in starting points are always available:
+
+```text
+/workflow saved code-review {"scope":"the current branch against main"}
+/workflow saved repository-audit
+/workflow saved migration-plan {"target":"move persistence from files to SQLite"}
+```
+
+A personal or project workflow with the same filename overrides the built-in.
+
+## JavaScript API
+
+Workflow scripts begin with a literal metadata export and may use these globals:
+
+* `agent(prompt, { label, tier, model?, tools?, disallowedTools? })`
+* `parallel(thunks)`
+* `pipeline(items, ...stages)`
+* `phase(title)`
+* `log(message)`
+* `retry(thunk, { attempts })`
+* `gate(thunk, validator, { attempts })`
+* `checkpoint(question)`
+* `workflow(name, args)` for a saved nested workflow
+* `budget`, `args`, and `cwd`
+
+## Security model
+
+Workflow execution requires Pi to mark the project as trusted. Every generated workflow is shown for approval before execution. The runtime uses Node's `vm` to constrain the script's normal globals and improve determinism, but `vm` is not a security sandbox. Run only generated or saved workflow JavaScript you trust.
+
+Subagents receive Pi's standard coding tools unless the script specifies a narrower `tools` allowlist. Repository writes are therefore possible and are called out in the approval preview.

--- a/extensions/workflow/README.md
+++ b/extensions/workflow/README.md
@@ -8,8 +8,11 @@ Requires Pi 0.80.10 or newer.
 
 ```text
 /workflow setup
+/workflow doctor
 /workflow run audit this repository from correctness, testing, and maintainability angles
 ```
+
+`/workflow help` is the in-Pi user guide. `/workflow doctor` is a read-only readiness check for extension activation, project trust, model configuration and availability, saved workflows, and visible run history. Doctor makes no model calls, changes no settings, and starts no workflows.
 
 Setup offers four profiles:
 

--- a/extensions/workflow/README.md
+++ b/extensions/workflow/README.md
@@ -66,12 +66,13 @@ Older persisted runs remain readable. Because their original schema did not reta
 
 ## JavaScript API
 
-Workflow scripts begin with a literal metadata export and may use these globals. Metadata phases may be written as `{ title: "Inspect" }` objects or plain strings; orchestration may be top-level or wrapped in `export default async function run()`.
+Workflow scripts begin with a literal metadata export and may use these globals. Metadata phases may be written as `{ title: "Inspect" }` objects or plain strings; orchestration may be top-level or wrapped in an async `run()` function. A trailing bare `run()` is normalized into an awaited call so its failures stay attached to the workflow run.
 
 * `agent(prompt, { label, tier, model?, tools?, disallowedTools? })`
+* `agent(persona, options)(task, overrides?)` for a reusable role
 * `parallel(thunks)`
 * `pipeline(items, ...stages)`
-* `phase(title)`
+* `phase(title)` or `phase(title, async () => ...)`
 * `log(message)`
 * `retry(thunk, { attempts })`
 * `gate(thunk, validator, { attempts })`
@@ -81,6 +82,8 @@ Workflow scripts begin with a literal metadata export and may use these globals.
 
 ## Security model
 
-Workflow execution requires Pi to mark the project as trusted. Every generated workflow is shown for approval before execution. The runtime uses Node's `vm` to constrain the script's normal globals and improve determinism, but `vm` is not a security sandbox. Run only generated or saved workflow JavaScript you trust.
+Workflow execution requires Pi to mark the project as trusted. Before execution, approval opens on the complete line-numbered JavaScript; Tab switches to the model, scale, tools, and security summary. Only an explicit `y` starts the run. The runtime uses Node's `vm` to constrain the script's normal globals and improve determinism, but `vm` is not a security sandbox. Run only generated or saved workflow JavaScript you trust.
 
 Subagents receive Pi's standard coding tools unless the script specifies a narrower `tools` allowlist. Repository writes are therefore possible and are called out in the approval preview.
+
+Background completion and failure notices are display-only. They do not automatically wake the parent model, so an invalid workflow cannot enter a retry and re-approval loop on its own.

--- a/extensions/workflow/README.md
+++ b/extensions/workflow/README.md
@@ -36,6 +36,7 @@ When routes are customized, the model picker starts from Pi's configured `enable
 * Project workflows: `.pi/workflows/*.js`
 * Personal workflows: `~/.pi/workflows/saved/*.js`
 * Run journals and results: `~/.pi/workflows/projects/<project-hash>/runs/*.json`
+* Exported reports: `~/.pi/workflows/projects/<project-hash>/exports/*.{md,html}`
 
 Project workflow files override personal files with the same filename. Run state stays outside the repository.
 
@@ -48,6 +49,20 @@ Three built-in starting points are always available:
 ```
 
 A personal or project workflow with the same filename overrides the built-in.
+
+## Run browser
+
+`/workflow` opens the interactive run browser. `/workflow runs` and `/workflow history` open the same view, while `/workflow active` starts with the active filter selected. History is project-scoped across Pi sessions, so restarting Pi does not hide an earlier run.
+
+Select a run and press Enter to inspect it. Completed runs open on the rendered Markdown result; running and paused runs open on progress. The detail view provides:
+
+* phase progress, elapsed time, token usage, and cost
+* complete agent prompts, recent tool activity, model routes, and results for newly recorded runs
+* the generated JavaScript source
+* copy, Markdown export, self-contained visual HTML save/open, and save-as-reusable-workflow actions
+* pause, resume, and stop controls for live runs
+
+Older persisted runs remain readable. Because their original schema did not retain agent prompts or tool activity, those two fields show a compatibility notice while their full results and usage remain available.
 
 ## JavaScript API
 

--- a/extensions/workflow/README.md
+++ b/extensions/workflow/README.md
@@ -27,6 +27,8 @@ Each profile maps four roles to an authenticated model and thinking level:
 * `reviewer` — independent criticism, preferably from another model family
 * `synthesizer` — final integration and judgment
 
+When routes are customized, the model picker starts from Pi's configured `enabledModels` scope and provides the same type-to-filter interaction as `/model`. This keeps provider catalogs with hundreds of entries out of the normal setup path.
+
 ## Storage
 
 * Global control settings: `~/.pi/workflows/control-plane.json`
@@ -49,7 +51,7 @@ A personal or project workflow with the same filename overrides the built-in.
 
 ## JavaScript API
 
-Workflow scripts begin with a literal metadata export and may use these globals:
+Workflow scripts begin with a literal metadata export and may use these globals. Metadata phases may be written as `{ title: "Inspect" }` objects or plain strings; orchestration may be top-level or wrapped in `export default async function run()`.
 
 * `agent(prompt, { label, tier, model?, tools?, disallowedTools? })`
 * `parallel(thunks)`

--- a/extensions/workflow/approval.ts
+++ b/extensions/workflow/approval.ts
@@ -1,0 +1,117 @@
+import { type ExtensionContext, type Theme } from "@earendil-works/pi-coding-agent";
+import { Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type TUI } from "@earendil-works/pi-tui";
+import { formatWorkflowApproval } from "./preview.js";
+import type { WorkflowPreview } from "./types.js";
+
+type ApprovalTab = "script" | "summary";
+
+export async function requestWorkflowApproval(
+  ctx: ExtensionContext,
+  preview: WorkflowPreview,
+): Promise<boolean> {
+  if (ctx.mode !== "tui") {
+    return ctx.ui.confirm(`Run workflow “${preview.name}”?`, `${formatWorkflowApproval(preview)}\n\nJavaScript:\n${preview.script}`);
+  }
+  return ctx.ui.custom<boolean>((tui, theme, _keybindings, done) =>
+    new WorkflowApprovalView(tui, theme, preview, done),
+  );
+}
+
+export class WorkflowApprovalView {
+  private tab: ApprovalTab = "script";
+  private scrollOffset = 0;
+  private totalLines = 0;
+  private viewHeight = 1;
+
+  constructor(
+    private readonly tui: TUI,
+    private readonly theme: Theme,
+    private readonly preview: WorkflowPreview,
+    private readonly done: (approved: boolean) => void,
+  ) {}
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    const height = Math.max(14, Math.floor((this.tui.terminal.rows || 24) * 0.82));
+    const innerWidth = Math.max(20, width - 2);
+    const contentHeight = Math.max(4, height - 9);
+    const tabs = this.tab === "script"
+      ? `${this.theme.fg("accent", "[JavaScript]")}  ${this.theme.fg("muted", "Summary")}`
+      : `${this.theme.fg("muted", "JavaScript")}  ${this.theme.fg("accent", "[Summary]")}`;
+    const content = this.tab === "script" ? this.scriptLines(innerWidth) : this.summaryLines(innerWidth);
+    this.totalLines = content.length;
+    this.viewHeight = contentHeight;
+    this.clampScroll();
+    const lines = [
+      this.theme.fg("accent", this.theme.bold(`Review workflow before running: ${this.preview.name}`)),
+      this.theme.fg("muted", `${this.preview.description} · ${this.preview.staticAgentCalls} agent call sites · ${this.preview.maxAgents} max`),
+      tabs,
+      "",
+      ...content.slice(this.scrollOffset, this.scrollOffset + contentHeight),
+    ];
+    while (lines.length < height - 3) lines.push("");
+    const range = this.totalLines > this.viewHeight
+      ? ` · ${this.scrollOffset + 1}-${Math.min(this.totalLines, this.scrollOffset + this.viewHeight)}/${this.totalLines}`
+      : "";
+    lines.push(this.theme.fg("dim", `tab/←→ script or summary · ↑↓/pgup/pgdn scroll${range}`));
+    lines.push(`${this.theme.fg("success", "y approve and run")} · ${this.theme.fg("error", "n/esc reject")}`);
+    return frame(this.theme, lines, width);
+  }
+
+  handleInput(data: string): void {
+    if (data.toLowerCase() === "y") return this.done(true);
+    if (data.toLowerCase() === "n" || matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+      return this.done(false);
+    }
+    if (matchesKey(data, Key.tab) || matchesKey(data, Key.left) || matchesKey(data, Key.right)) {
+      this.tab = this.tab === "script" ? "summary" : "script";
+      this.scrollOffset = 0;
+      this.tui.requestRender();
+      return;
+    }
+    let delta = 0;
+    if (matchesKey(data, Key.up)) delta = -1;
+    else if (matchesKey(data, Key.down)) delta = 1;
+    else if (matchesKey(data, Key.pageUp)) delta = -this.viewHeight;
+    else if (matchesKey(data, Key.pageDown)) delta = this.viewHeight;
+    else return;
+    this.scrollOffset += delta;
+    this.clampScroll();
+    this.tui.requestRender();
+  }
+
+  private scriptLines(width: number): string[] {
+    const numberWidth = String(this.preview.script.split(/\r?\n/).length).length;
+    return this.preview.script.split(/\r?\n/).flatMap((line, index) => {
+      const prefix = `${String(index + 1).padStart(numberWidth)} │ `;
+      const wrapped = wrapTextWithAnsi(line || " ", Math.max(8, width - visibleWidth(prefix)));
+      return wrapped.map((part, partIndex) =>
+        `${this.theme.fg("dim", partIndex === 0 ? prefix : " ".repeat(visibleWidth(prefix)))}${this.theme.fg("text", part)}`,
+      );
+    });
+  }
+
+  private summaryLines(width: number): string[] {
+    return formatWorkflowApproval(this.preview).split(/\r?\n/).flatMap((line) =>
+      wrapTextWithAnsi(line || " ", width),
+    );
+  }
+
+  private clampScroll(): void {
+    this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, Math.max(0, this.totalLines - this.viewHeight)));
+  }
+}
+
+function frame(theme: Theme, lines: string[], width: number): string[] {
+  const innerWidth = Math.max(10, width - 2);
+  const border = (text: string) => theme.fg("borderMuted", text);
+  return [
+    border(`┌${"─".repeat(innerWidth)}┐`),
+    ...lines.map((line) => {
+      const truncated = truncateToWidth(line, innerWidth);
+      return `${border("│")}${truncated}${" ".repeat(Math.max(0, innerWidth - visibleWidth(truncated)))}${border("│")}`;
+    }),
+    border(`└${"─".repeat(innerWidth)}┘`),
+  ].map((line) => truncateToWidth(line, width));
+}

--- a/extensions/workflow/config.ts
+++ b/extensions/workflow/config.ts
@@ -1,0 +1,132 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  WORKFLOW_PROFILE_NAMES,
+  WORKFLOW_ROLES,
+  WORKFLOW_THINKING_LEVELS,
+  type WorkflowApprovalMode,
+  type WorkflowControlSettings,
+  type WorkflowProfileName,
+  type WorkflowRole,
+  type WorkflowRoleRoute,
+  type WorkflowThinkingLevel,
+} from "./types.js";
+
+const GLOBAL_SETTINGS_PATH = join(homedir(), ".pi", "workflows", "control-plane.json");
+const PROJECT_SETTINGS_RELATIVE_PATH = join(".pi", "workflow.json");
+
+export interface WorkflowSettingsPaths {
+  globalPath?: string;
+  projectPath?: string;
+}
+
+export function getWorkflowControlGlobalPath(): string {
+  return GLOBAL_SETTINGS_PATH;
+}
+
+export function getWorkflowControlProjectPath(cwd: string): string {
+  return join(cwd, PROJECT_SETTINGS_RELATIVE_PATH);
+}
+
+export function loadWorkflowControlSettings(
+  cwd: string,
+  paths: WorkflowSettingsPaths = {},
+): WorkflowControlSettings | undefined {
+  const global = readSettings(paths.globalPath ?? getWorkflowControlGlobalPath());
+  const project = readSettings(paths.projectPath ?? getWorkflowControlProjectPath(cwd));
+  return project ?? global;
+}
+
+export function saveWorkflowControlSettings(
+  settings: WorkflowControlSettings,
+  cwd: string,
+  scope: "global" | "project",
+  paths: WorkflowSettingsPaths = {},
+): string {
+  const path =
+    scope === "project"
+      ? (paths.projectPath ?? getWorkflowControlProjectPath(cwd))
+      : (paths.globalPath ?? getWorkflowControlGlobalPath());
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(normalizeSettings(settings), null, 2)}\n`, "utf8");
+  return path;
+}
+
+function readSettings(path: string): WorkflowControlSettings | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    return normalizeSettings(JSON.parse(readFileSync(path, "utf8")));
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeSettings(value: unknown): WorkflowControlSettings | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const raw = value as Record<string, unknown>;
+  const profile = normalizeProfile(raw.profile);
+  const routes = normalizeRoutes(raw.routes);
+  if (!profile || !routes) return undefined;
+
+  const limits = profileLimits(profile);
+  return {
+    version: 1,
+    profile,
+    routes,
+    concurrency: normalizeInteger(raw.concurrency, 1, 16) ?? limits.concurrency,
+    maxAgents: normalizeInteger(raw.maxAgents, 1, 1000) ?? limits.maxAgents,
+    approvalMode: normalizeApprovalMode(raw.approvalMode) ?? "always",
+  };
+}
+
+function normalizeProfile(value: unknown): WorkflowProfileName | undefined {
+  return typeof value === "string" && WORKFLOW_PROFILE_NAMES.includes(value as WorkflowProfileName)
+    ? (value as WorkflowProfileName)
+    : undefined;
+}
+
+function normalizeApprovalMode(value: unknown): WorkflowApprovalMode | undefined {
+  return value === "always" || value === "generated" ? value : undefined;
+}
+
+function normalizeRoutes(value: unknown): Record<WorkflowRole, WorkflowRoleRoute> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const raw = value as Record<string, unknown>;
+  const routes = {} as Record<WorkflowRole, WorkflowRoleRoute>;
+  for (const role of WORKFLOW_ROLES) {
+    const route = raw[role];
+    if (!route || typeof route !== "object" || Array.isArray(route)) return undefined;
+    const candidate = route as Record<string, unknown>;
+    if (typeof candidate.model !== "string" || !candidate.model.trim()) return undefined;
+    if (
+      typeof candidate.thinking !== "string" ||
+      !WORKFLOW_THINKING_LEVELS.includes(candidate.thinking as WorkflowThinkingLevel)
+    ) {
+      return undefined;
+    }
+    routes[role] = {
+      model: candidate.model.trim(),
+      thinking: candidate.thinking as WorkflowThinkingLevel,
+    };
+  }
+  return routes;
+}
+
+function normalizeInteger(value: unknown, min: number, max: number): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < min) return undefined;
+  return Math.min(max, Math.floor(value));
+}
+
+export function profileLimits(profile: WorkflowProfileName): { concurrency: number; maxAgents: number } {
+  switch (profile) {
+    case "lean":
+      return { concurrency: 3, maxAgents: 8 };
+    case "balanced":
+      return { concurrency: 4, maxAgents: 15 };
+    case "deep":
+      return { concurrency: 6, maxAgents: 40 };
+    case "custom":
+      return { concurrency: 4, maxAgents: 15 };
+  }
+}

--- a/extensions/workflow/discovery.ts
+++ b/extensions/workflow/discovery.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseWorkflowScript } from "./runtime.js";
+import type { SavedWorkflowFile } from "./types.js";
+
+export interface WorkflowDiscoveryOptions {
+  projectDir?: string;
+  userDir?: string;
+  builtInDir?: string | null;
+}
+
+export function getProjectWorkflowDir(cwd: string): string {
+  return join(cwd, ".pi", "workflows");
+}
+
+export function getUserWorkflowDir(): string {
+  return join(homedir(), ".pi", "workflows", "saved");
+}
+
+export function getBuiltInWorkflowDir(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "examples");
+}
+
+export function discoverWorkflowFiles(
+  cwd: string,
+  options: WorkflowDiscoveryOptions = {},
+): SavedWorkflowFile[] {
+  const project = readWorkflowDir(options.projectDir ?? getProjectWorkflowDir(cwd), "project");
+  const user = readWorkflowDir(options.userDir ?? getUserWorkflowDir(), "user");
+  const builtIn = readWorkflowDir(
+    options.builtInDir === undefined ? getBuiltInWorkflowDir() : options.builtInDir,
+    "built-in",
+  );
+  const discovered = new Map<string, SavedWorkflowFile>();
+
+  for (const workflow of builtIn) discovered.set(workflow.id, workflow);
+  for (const workflow of user) discovered.set(workflow.id, workflow);
+  for (const workflow of project) discovered.set(workflow.id, workflow);
+  return [...discovered.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function loadWorkflowFile(
+  cwd: string,
+  name: string,
+  options: WorkflowDiscoveryOptions = {},
+): SavedWorkflowFile | undefined {
+  const normalized = name.trim().replace(/\.js$/i, "");
+  return discoverWorkflowFiles(cwd, options).find(
+    (workflow) => workflow.id === normalized || workflow.name === normalized,
+  );
+}
+
+function readWorkflowDir(dir: string | null, location: "project" | "user" | "built-in"): SavedWorkflowFile[] {
+  if (!dir) return [];
+  if (!existsSync(dir)) return [];
+  const files: SavedWorkflowFile[] = [];
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".js")) continue;
+    const path = join(dir, entry.name);
+    try {
+      const script = readFileSync(path, "utf8");
+      const { meta } = parseWorkflowScript(script);
+      files.push({
+        id: basename(entry.name, ".js"),
+        name: meta.name,
+        description: meta.description,
+        phases: meta.phases?.map((phase) => phase.title) ?? [],
+        path,
+        location,
+        script,
+      });
+    } catch {
+      // Invalid JavaScript workflows stay invisible until they pass runtime parsing.
+    }
+  }
+  return files;
+}

--- a/extensions/workflow/examples/code-review.js
+++ b/extensions/workflow/examples/code-review.js
@@ -1,0 +1,32 @@
+export const meta = {
+  name: "code_review",
+  description: "Review a change from correctness, testing, and maintainability angles",
+  phases: [{ title: "Inspect" }, { title: "Synthesize" }],
+};
+
+const scope = String(args?.scope ?? "the current uncommitted changes");
+phase("Inspect");
+const findings = await parallel([
+  () => agent(`Review ${scope} for correctness bugs and edge cases. Cite files and evidence.`, {
+    label: "correctness review",
+    tier: "reviewer",
+    tools: ["read", "bash"],
+  }),
+  () => agent(`Review ${scope} for missing, weak, or misleading tests. Cite concrete gaps.`, {
+    label: "test review",
+    tier: "reviewer",
+    tools: ["read", "bash"],
+  }),
+  () => agent(`Review ${scope} for maintainability and architecture risks. Avoid style-only comments.`, {
+    label: "design review",
+    tier: "reviewer",
+    tools: ["read", "bash"],
+  }),
+]);
+
+phase("Synthesize");
+const verdict = await agent(
+  `Deduplicate and rank these review findings by severity and confidence. Keep only actionable, evidenced findings:\n\n${findings.filter(Boolean).join("\n\n")}`,
+  { label: "review verdict", tier: "synthesizer", tools: ["read"] },
+);
+return { scope, findings, verdict };

--- a/extensions/workflow/examples/migration-plan.js
+++ b/extensions/workflow/examples/migration-plan.js
@@ -1,0 +1,39 @@
+export const meta = {
+  name: "migration_plan",
+  description: "Develop and stress-test an evidence-based migration plan",
+  phases: [{ title: "Investigate" }, { title: "Design" }, { title: "Challenge" }, { title: "Finalize" }],
+};
+
+const target = String(args?.target ?? "the requested migration");
+phase("Investigate");
+const evidence = await parallel([
+  () => agent(`Inspect the current implementation relevant to ${target}. Identify boundaries, dependencies, and constraints with file evidence.`, {
+    label: "current state",
+    tier: "scout",
+    tools: ["read", "bash"],
+  }),
+  () => agent(`Investigate compatibility, data, API, and rollout constraints for ${target}. Cite repository evidence.`, {
+    label: "migration constraints",
+    tier: "worker",
+    tools: ["read", "bash"],
+  }),
+]);
+
+phase("Design");
+const draft = await agent(
+  `Design a vertical, reversible migration plan for ${target}. Include verification and rollback at each increment.\n\n${evidence.filter(Boolean).join("\n\n")}`,
+  { label: "draft plan", tier: "worker", tools: ["read"] },
+);
+
+phase("Challenge");
+const critique = await agent(
+  `Stress-test this migration plan for hidden assumptions, unsafe sequencing, missing verification, and rollback gaps:\n\n${draft}`,
+  { label: "plan challenge", tier: "reviewer", tools: ["read"] },
+);
+
+phase("Finalize");
+const plan = await agent(
+  `Produce the final migration plan for ${target}. Resolve valid critique, keep increments usable, and distinguish confirmed facts from assumptions.\n\nDRAFT:\n${draft}\n\nCRITIQUE:\n${critique}`,
+  { label: "final plan", tier: "synthesizer", tools: ["read"] },
+);
+return { target, evidence, draft, critique, plan };

--- a/extensions/workflow/examples/repository-audit.js
+++ b/extensions/workflow/examples/repository-audit.js
@@ -1,0 +1,42 @@
+export const meta = {
+  name: "repository_audit",
+  description: "Audit a repository across architecture, security, testing, and operability",
+  phases: [{ title: "Map" }, { title: "Audit" }, { title: "Synthesize" }],
+};
+
+phase("Map");
+const map = await agent(
+  "Map the repository architecture, entry points, state boundaries, and test strategy. Cite the most relevant paths.",
+  { label: "repository map", tier: "scout", tools: ["read", "bash"] },
+);
+
+phase("Audit");
+const audits = await parallel([
+  () => agent(`Using this repository map, find concrete architecture and maintainability risks:\n${map}`, {
+    label: "architecture audit",
+    tier: "worker",
+    tools: ["read", "bash"],
+  }),
+  () => agent(`Using this repository map, find concrete security and trust-boundary risks:\n${map}`, {
+    label: "security audit",
+    tier: "reviewer",
+    tools: ["read", "bash"],
+  }),
+  () => agent(`Using this repository map, find important test and verification gaps:\n${map}`, {
+    label: "testing audit",
+    tier: "worker",
+    tools: ["read", "bash"],
+  }),
+  () => agent(`Using this repository map, find deployment, recovery, and operability risks:\n${map}`, {
+    label: "operations audit",
+    tier: "reviewer",
+    tools: ["read", "bash"],
+  }),
+]);
+
+phase("Synthesize");
+const report = await agent(
+  `Produce a prioritized repository audit. Deduplicate claims, preserve file evidence, state uncertainty, and cap the final list at ten findings.\n\n${audits.filter(Boolean).join("\n\n")}`,
+  { label: "audit report", tier: "synthesizer", tools: ["read"] },
+);
+return { map, audits, report };

--- a/extensions/workflow/help.ts
+++ b/extensions/workflow/help.ts
@@ -1,0 +1,93 @@
+import { WORKFLOW_ROLES, type WorkflowControlSettings, type WorkflowRole } from "./types.js";
+
+export interface WorkflowDoctorReport {
+  extensionActive: boolean;
+  projectTrusted: boolean;
+  settings?: WorkflowControlSettings;
+  availableModels: number;
+  missingRoles: WorkflowRole[];
+  savedWorkflows: number;
+  runHistory: number;
+}
+
+export function formatWorkflowHelp(): string {
+  return [
+    "Workflow — inspectable, model-routed multi-agent work",
+    "",
+    "Quick start",
+    "  1. /workflow setup",
+    "     Choose Lean, Balanced, Deep, or Custom and review each model route.",
+    "  2. /workflow run <what you want accomplished>",
+    "     Pi generates the orchestration but does not start it yet.",
+    "  3. Review the complete JavaScript approval screen.",
+    "     Tab/←/→ switches code and summary · ↑/↓/PgUp/PgDn scrolls · y runs · n/Esc rejects.",
+    "  4. /workflow history",
+    "     Open the result, agent evidence, generated script, usage, and export actions.",
+    "",
+    "Run and inspect",
+    "  /workflow                         open the run browser",
+    "  /workflow run <prompt>            generate, review, and run a workflow",
+    "  /workflow saved <name> [json]     review and run saved JavaScript",
+    "  /workflow active                  inspect running or paused workflows",
+    "  /workflow history                 inspect all project workflow runs",
+    "  /workflow status <run-id>         print one run's status",
+    "",
+    "Configure and control",
+    "  /workflow setup                   choose model routes, limits, and approval policy",
+    "  /workflow settings                show the effective configuration",
+    "  /workflow list                    list built-in, personal, and project workflows",
+    "  /workflow pause|resume|stop <id>  control a live run",
+    "  /workflow remove <id>             delete a persisted run",
+    "",
+    "Verify safely",
+    "  /workflow doctor                  read-only readiness check; no model calls or workflows",
+    "",
+    "Background results are displayed without waking the parent model. A failed run will not retry or ask for approval again on its own.",
+  ].join("\n");
+}
+
+export function formatWorkflowDoctor(report: WorkflowDoctorReport): string {
+  const configured = Boolean(report.settings);
+  const routesReady = configured && report.availableModels > 0 && report.missingRoles.length === 0;
+  const ready = report.extensionActive && report.projectTrusted && routesReady;
+  const lines = [
+    "Workflow doctor — read-only readiness check",
+    "",
+    check(report.extensionActive, "Workflow extension is active", "Workflow tool is not active"),
+    check(report.projectTrusted, "Project is trusted", "Project is not trusted; restart Pi with --approve"),
+    configured
+      ? check(true, `Model profile is configured: ${report.settings?.profile}`)
+      : check(false, "Model profile is not configured; run /workflow setup"),
+  ];
+
+  if (!configured) {
+    lines.push(check(false, "Model routes cannot be checked before setup"));
+  } else if (!report.availableModels) {
+    lines.push(check(false, "No authenticated models are available"));
+  } else if (report.missingRoles.length) {
+    lines.push(check(false, `Unavailable model routes: ${report.missingRoles.join(", ")}; run /workflow setup again`));
+  } else {
+    lines.push(check(true, `All ${WORKFLOW_ROLES.length} model routes are available (${report.availableModels} authenticated models)`));
+  }
+
+  lines.push(
+    check(true, `${report.savedWorkflows} saved or built-in workflows discovered`),
+    check(true, `${report.runHistory} project runs visible in history`),
+    "",
+    ready ? "Ready. Try: /workflow run inspect this repository and report the highest-risk issue" : nextStep(report),
+    "Approval must show the complete JavaScript before any agents start.",
+    "This check made no model calls, changed no settings, and started no workflows.",
+  );
+  return lines.join("\n");
+}
+
+function check(ok: boolean, success: string, failure = success): string {
+  return `${ok ? "✓" : "✗"} ${ok ? success : failure}`;
+}
+
+function nextStep(report: WorkflowDoctorReport): string {
+  if (!report.extensionActive) return "Not ready. Reload Pi with the workflow extension enabled.";
+  if (!report.projectTrusted) return "Not ready. Restart Pi with --approve, then run /workflow doctor again.";
+  if (!report.settings) return "Not ready. Run /workflow setup, then /workflow doctor again.";
+  return "Not ready. Run /workflow setup again and choose available authenticated models.";
+}

--- a/extensions/workflow/index.ts
+++ b/extensions/workflow/index.ts
@@ -25,7 +25,7 @@ import {
   toModelTierConfig,
   workflowRoleGuideline,
 } from "./profiles.js";
-import { applyWorkflowLimits, createWorkflowPreview, formatWorkflowApproval } from "./preview.js";
+import { applyWorkflowLimits, createWorkflowPreview } from "./preview.js";
 import {
   WORKFLOW_PROFILE_NAMES,
   WORKFLOW_ROLES,
@@ -39,6 +39,7 @@ import {
   type WorkflowThinkingLevel,
 } from "./types.js";
 import { WorkflowModelSelector } from "./model-selector.js";
+import { requestWorkflowApproval } from "./approval.js";
 import { openWorkflowRunBrowser } from "./run-browser.js";
 import { installWorkflowResultDelivery, installWorkflowTaskPanel } from "./ui.js";
 
@@ -454,7 +455,7 @@ async function requireWorkflowApproval(
   if (!ctx.hasUI) {
     throw new Error("This workflow requires interactive approval. Run it from Pi's TUI or RPC mode.");
   }
-  const approved = await ctx.ui.confirm(`Run workflow “${preview.name}”?`, formatWorkflowApproval(preview));
+  const approved = await requestWorkflowApproval(ctx, preview);
   if (!approved) throw new Error("Workflow cancelled by the user before execution.");
 }
 

--- a/extensions/workflow/index.ts
+++ b/extensions/workflow/index.ts
@@ -40,6 +40,7 @@ import {
 } from "./types.js";
 import { WorkflowModelSelector } from "./model-selector.js";
 import { requestWorkflowApproval } from "./approval.js";
+import { formatWorkflowDoctor, formatWorkflowHelp } from "./help.js";
 import { openWorkflowRunBrowser } from "./run-browser.js";
 import { installWorkflowResultDelivery, installWorkflowTaskPanel } from "./ui.js";
 
@@ -56,6 +57,8 @@ const USAGE = [
   "  /workflow remove <id>             delete a persisted run",
   "  /workflow setup                   configure profile and model routes",
   "  /workflow settings                show effective settings",
+  "  /workflow doctor                  verify readiness without model calls",
+  "  /workflow help                    show the complete user guide",
 ].join("\n");
 
 const PROFILE_LABELS: Record<WorkflowProfileName, string> = {
@@ -191,8 +194,11 @@ function registerWorkflowCommand(
         case "settings":
           await showSettings(pi, cwd);
           return;
+        case "doctor":
+          await showDoctor(pi, manager, cwd, toolName, ctx);
+          return;
         case "help":
-          await print(pi, USAGE);
+          await print(pi, formatWorkflowHelp());
           return;
         default:
           ctx.ui.notify(`Unknown workflow action "${command}".`, "warning");
@@ -526,6 +532,35 @@ async function showRunStatus(pi: ExtensionAPI, manager: WorkflowManager, id?: st
 async function showSettings(pi: ExtensionAPI, cwd: string): Promise<void> {
   const settings = loadWorkflowControlSettings(cwd);
   await print(pi, settings ? formatSettings(settings) : "Workflow is not configured. Run /workflow setup.");
+}
+
+async function showDoctor(
+  pi: ExtensionAPI,
+  manager: WorkflowManager,
+  cwd: string,
+  toolName: string,
+  ctx: ExtensionCommandContext,
+): Promise<void> {
+  const settings = loadWorkflowControlSettings(cwd);
+  let candidates: WorkflowModelCandidate[] = [];
+  try {
+    candidates = toModelCandidates(ctx.modelRegistry.getAvailable());
+  } catch {
+    // The report remains useful when a provider cannot enumerate its catalog.
+  }
+  const available = new Set(candidates.map((candidate) => candidate.spec));
+  const missingRoles = settings
+    ? WORKFLOW_ROLES.filter((role) => !available.has(settings.routes[role].model))
+    : [];
+  await print(pi, formatWorkflowDoctor({
+    extensionActive: pi.getActiveTools().includes(toolName),
+    projectTrusted: ctx.isProjectTrusted(),
+    settings,
+    availableModels: candidates.length,
+    missingRoles,
+    savedWorkflows: discoverWorkflowFiles(cwd).length,
+    runHistory: manager.listAllRuns().length,
+  }));
 }
 
 function formatSettings(settings: WorkflowControlSettings): string {

--- a/extensions/workflow/index.ts
+++ b/extensions/workflow/index.ts
@@ -1,0 +1,560 @@
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+  buildForcedWorkflowPrompt,
+  createWorkflowTool,
+  saveModelTierConfig,
+  WorkflowManager,
+  type WorkflowToolInput,
+} from "./runtime.js";
+import {
+  loadWorkflowControlSettings,
+  profileLimits,
+  saveWorkflowControlSettings,
+} from "./config.js";
+import { discoverWorkflowFiles, loadWorkflowFile } from "./discovery.js";
+import {
+  routeSpec,
+  suggestWorkflowSettings,
+  toModelCandidates,
+  toModelTierConfig,
+  workflowRoleGuideline,
+} from "./profiles.js";
+import { applyWorkflowLimits, createWorkflowPreview, formatWorkflowApproval } from "./preview.js";
+import {
+  WORKFLOW_PROFILE_NAMES,
+  WORKFLOW_ROLES,
+  WORKFLOW_THINKING_LEVELS,
+  type SavedWorkflowFile,
+  type WorkflowApprovalMode,
+  type WorkflowControlSettings,
+  type WorkflowModelCandidate,
+  type WorkflowProfileName,
+  type WorkflowRole,
+  type WorkflowThinkingLevel,
+} from "./types.js";
+import { installWorkflowResultDelivery, installWorkflowTaskPanel } from "./ui.js";
+
+const USAGE = [
+  "Usage:",
+  "  /workflow                         open the workflow hub",
+  "  /workflow run <prompt>            generate and run a workflow",
+  "  /workflow saved <name> [json]     run a saved JavaScript workflow",
+  "  /workflow list                    list saved workflow files",
+  "  /workflow active | history        inspect runs",
+  "  /workflow status <id>             inspect one run",
+  "  /workflow pause|resume|stop <id>  control a run",
+  "  /workflow remove <id>             delete a persisted run",
+  "  /workflow setup                   configure profile and model routes",
+  "  /workflow settings                show effective settings",
+].join("\n");
+
+const PROFILE_LABELS: Record<WorkflowProfileName, string> = {
+  lean: "Lean — small fan-out, lowest practical cost",
+  balanced: "Balanced — deliberate routing for everyday work (recommended)",
+  deep: "Deep — stronger models and wider fan-out",
+  custom: "Custom — choose every route and limit",
+};
+
+export interface WorkflowExtensionOptions {
+  cwd?: string;
+  runsDir?: string;
+}
+
+export function createWorkflowExtension(options: WorkflowExtensionOptions = {}): (pi: ExtensionAPI) => void {
+  return function workflowExtension(pi: ExtensionAPI): void {
+    const cwd = options.cwd ?? process.cwd();
+    const manager = new WorkflowManager({
+      cwd,
+      runsDir: options.runsDir,
+      loadSavedWorkflow: (name) => loadWorkflowFile(cwd, name)?.script,
+    });
+    const workflowTool = createWorkflowTool({ cwd, manager });
+    const upstreamExecute = workflowTool.execute.bind(workflowTool);
+    const upstreamGuidelines = [...(workflowTool.promptGuidelines ?? [])];
+
+    Object.defineProperty(workflowTool, "promptGuidelines", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        const settings = loadWorkflowControlSettings(cwd);
+        return settings
+          ? [...upstreamGuidelines, workflowRoleGuideline(settings)]
+          : [...upstreamGuidelines, "Workflow model roles are not configured. Ask the user to run /workflow setup first."];
+      },
+    });
+
+    workflowTool.execute = async (toolCallId, input, signal, onUpdate, ctx) => {
+      const settings = requireConfiguredSettings(cwd);
+      requireTrustedProject(ctx);
+      assertConfiguredModels(settings, toModelCandidates(ctx.modelRegistry.getAvailable()));
+      saveModelTierConfig(toModelTierConfig(settings));
+
+      const limited = applyWorkflowLimits(input as WorkflowToolInput, settings);
+      const preview = createWorkflowPreview(limited.script, settings, "generated", limited);
+      await requireWorkflowApproval(ctx, preview, true);
+      return upstreamExecute(toolCallId, limited, signal, onUpdate, ctx);
+    };
+
+    pi.registerTool(workflowTool);
+    registerWorkflowCommand(pi, manager, cwd, workflowTool.name);
+
+    pi.on("session_start", (_event, ctx) => {
+      manager.setMainModel(ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined);
+      manager.setModelRegistry(ctx.modelRegistry);
+      try {
+        manager.setSessionId(ctx.sessionManager?.getSessionId());
+      } catch {
+        manager.setSessionId(undefined);
+      }
+
+      if (ctx.isProjectTrusted()) {
+        const active = pi.getActiveTools();
+        if (!active.includes(workflowTool.name)) pi.setActiveTools([...active, workflowTool.name]);
+      }
+      installWorkflowResultDelivery(pi, manager);
+      if (ctx.mode === "tui") installWorkflowTaskPanel(manager, ctx.ui);
+    });
+  };
+}
+
+export default createWorkflowExtension();
+
+function registerWorkflowCommand(
+  pi: ExtensionAPI,
+  manager: WorkflowManager,
+  cwd: string,
+  toolName: string,
+): void {
+  pi.registerCommand("workflow", {
+    description: "Run and manage dynamic workflows with explicit model profiles and approval",
+    async handler(rawArgs, ctx) {
+      const args = rawArgs.trim();
+      if (!args) {
+        await openWorkflowHub(pi, manager, cwd, toolName, ctx);
+        return;
+      }
+
+      const [command = "", ...rest] = args.split(/\s+/);
+      const tail = args.slice(command.length).trim();
+      switch (command.toLowerCase()) {
+        case "run":
+          await runGeneratedWorkflow(pi, cwd, toolName, tail, ctx);
+          return;
+        case "saved":
+          await runSavedWorkflow(manager, cwd, rest[0], tail.slice(rest[0]?.length ?? 0).trim(), ctx);
+          return;
+        case "list":
+          await showSavedWorkflows(pi, cwd);
+          return;
+        case "active":
+          await showRuns(pi, manager, true);
+          return;
+        case "history":
+          await showRuns(pi, manager, false);
+          return;
+        case "status":
+          await showRunStatus(pi, manager, rest[0]);
+          return;
+        case "pause":
+          notifyControl(ctx, rest[0], "pause", (id) => manager.pause(id));
+          return;
+        case "resume":
+          await resumeRun(manager, rest[0], ctx);
+          return;
+        case "stop":
+          notifyControl(ctx, rest[0], "stop", (id) => manager.stop(id));
+          return;
+        case "remove":
+        case "rm":
+          notifyControl(ctx, rest[0], "remove", (id) => manager.deleteRun(id));
+          return;
+        case "setup":
+          await setupWorkflow(cwd, ctx, normalizeProfile(rest[0]));
+          return;
+        case "settings":
+          await showSettings(pi, cwd);
+          return;
+        case "help":
+          await print(pi, USAGE);
+          return;
+        default:
+          ctx.ui.notify(`Unknown workflow action "${command}".`, "warning");
+          await print(pi, USAGE);
+      }
+    },
+  });
+}
+
+async function openWorkflowHub(
+  pi: ExtensionAPI,
+  manager: WorkflowManager,
+  cwd: string,
+  toolName: string,
+  ctx: ExtensionCommandContext,
+): Promise<void> {
+  if (!ctx.hasUI) {
+    await print(pi, USAGE);
+    return;
+  }
+  const action = await ctx.ui.select("Workflow", [
+    "Run a dynamic workflow",
+    "Run a saved workflow",
+    "Active runs",
+    "Run history",
+    "Setup model profile",
+    "Show settings",
+  ]);
+  switch (action) {
+    case "Run a dynamic workflow": {
+      const prompt = await ctx.ui.editor("What should the workflow accomplish?", "");
+      if (prompt?.trim()) await runGeneratedWorkflow(pi, cwd, toolName, prompt.trim(), ctx);
+      return;
+    }
+    case "Run a saved workflow": {
+      const workflows = discoverWorkflowFiles(cwd);
+      if (!workflows.length) return ctx.ui.notify("No saved .js workflows found.", "info");
+      const labels = workflows.map((workflow) => workflowLabel(workflow));
+      const selected = await ctx.ui.select("Saved workflow", labels);
+      const workflow = workflows[labels.indexOf(selected ?? "")];
+      if (workflow) await runSavedWorkflow(manager, cwd, workflow.id, "", ctx);
+      return;
+    }
+    case "Active runs":
+      await showRuns(pi, manager, true);
+      return;
+    case "Run history":
+      await showRuns(pi, manager, false);
+      return;
+    case "Setup model profile":
+      await setupWorkflow(cwd, ctx);
+      return;
+    case "Show settings":
+      await showSettings(pi, cwd);
+      return;
+  }
+}
+
+async function runGeneratedWorkflow(
+  pi: ExtensionAPI,
+  cwd: string,
+  toolName: string,
+  prompt: string,
+  ctx: ExtensionCommandContext,
+): Promise<void> {
+  if (!prompt) return ctx.ui.notify("Usage: /workflow run <prompt>", "warning");
+  requireTrustedProject(ctx);
+  let settings = loadWorkflowControlSettings(cwd);
+  if (!settings) {
+    if (!ctx.hasUI) throw new Error("Workflow setup is required. Run /workflow setup in interactive mode.");
+    ctx.ui.notify("Choose a model profile before the first workflow run.", "info");
+    settings = await setupWorkflow(cwd, ctx);
+    if (!settings) return;
+  }
+  assertConfiguredModels(settings, toModelCandidates(ctx.modelRegistry.getAvailable()));
+  saveModelTierConfig(toModelTierConfig(settings));
+
+  const active = pi.getActiveTools();
+  if (!active.includes(toolName)) pi.setActiveTools([...active, toolName]);
+  const directive = [
+    workflowRoleGuideline(settings),
+    "The workflow tool will show the completed JavaScript plan to the user for approval before execution.",
+  ].join(" ");
+  const forcedPrompt = buildForcedWorkflowPrompt(prompt, directive);
+  ctx.ui.notify(`Preparing ${settings.profile} workflow for approval…`, "info");
+  await pi.sendMessage(
+    { customType: "workflow-run", content: forcedPrompt, display: true },
+    { triggerTurn: true, deliverAs: "followUp" },
+  );
+}
+
+async function runSavedWorkflow(
+  manager: WorkflowManager,
+  cwd: string,
+  name: string | undefined,
+  rawArgs: string,
+  ctx: ExtensionCommandContext,
+): Promise<void> {
+  if (!name) return ctx.ui.notify("Usage: /workflow saved <name> [json args]", "warning");
+  requireTrustedProject(ctx);
+  const settings = requireConfiguredSettings(cwd);
+  assertConfiguredModels(settings, toModelCandidates(ctx.modelRegistry.getAvailable()));
+  const workflow = loadWorkflowFile(cwd, name);
+  if (!workflow) return ctx.ui.notify(`No saved workflow "${name}".`, "error");
+
+  let args: unknown;
+  if (rawArgs) {
+    try {
+      args = JSON.parse(rawArgs);
+    } catch {
+      return ctx.ui.notify("Saved workflow arguments must be valid JSON.", "error");
+    }
+  }
+
+  saveModelTierConfig(toModelTierConfig(settings));
+  const preview = createWorkflowPreview(workflow.script, settings, "saved");
+  await requireWorkflowApproval(ctx, preview, settings.approvalMode === "always");
+  const { runId, promise } = manager.startInBackground(workflow.script, args, {
+    concurrency: settings.concurrency,
+    maxAgents: settings.maxAgents,
+    confirm: ctx.hasUI
+      ? (question) => ctx.ui.input("Workflow checkpoint", String(question))
+      : undefined,
+  });
+  void promise.catch(() => {});
+  ctx.ui.notify(`Started ${workflow.name} in the background (${runId}).`, "info");
+}
+
+async function setupWorkflow(
+  cwd: string,
+  ctx: ExtensionCommandContext,
+  requestedProfile?: WorkflowProfileName,
+): Promise<WorkflowControlSettings | undefined> {
+  if (!ctx.hasUI) {
+    ctx.ui.notify("Workflow setup requires interactive mode.", "error");
+    return undefined;
+  }
+  const candidates = toModelCandidates(ctx.modelRegistry.getAvailable());
+  const currentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+  if (!candidates.length && !currentModel) {
+    ctx.ui.notify("No authenticated models are available.", "error");
+    return undefined;
+  }
+
+  const profile = requestedProfile ?? (await chooseProfile(ctx));
+  if (!profile) return undefined;
+  const baseProfile = profile === "custom" ? "balanced" : profile;
+  let settings = suggestWorkflowSettings(baseProfile, candidates, currentModel);
+  if (profile === "custom") settings = { ...settings, profile: "custom" };
+
+  if (profile !== "custom") {
+    const routing = await ctx.ui.select("Model routing", [
+      "Use suggested role routing (recommended)",
+      "Customize models and effort",
+    ]);
+    if (!routing) return undefined;
+    if (routing === "Customize models and effort") {
+      const customized = await customizeRoutes(settings, candidates, ctx);
+      if (!customized) return undefined;
+      settings = customized;
+    }
+  } else {
+    const customized = await customizeRoutes(settings, candidates, ctx, true);
+    if (!customized) return undefined;
+    settings = customized;
+  }
+
+  if (profile === "custom") {
+    const concurrency = await askInteger(ctx, "Maximum concurrent agents", settings.concurrency, 1, 16);
+    if (concurrency === undefined) return undefined;
+    const maxAgents = await askInteger(ctx, "Maximum agents per workflow", settings.maxAgents, 1, 1000);
+    if (maxAgents === undefined) return undefined;
+    settings = { ...settings, concurrency, maxAgents };
+  } else {
+    const limits = profileLimits(profile);
+    settings = { ...settings, concurrency: limits.concurrency, maxAgents: limits.maxAgents };
+  }
+
+  const approval = await ctx.ui.select("Approval policy", [
+    "Review every workflow (recommended)",
+    "Review generated workflows; trust saved files",
+  ]);
+  if (!approval) return undefined;
+  const approvalMode: WorkflowApprovalMode = approval.startsWith("Review every") ? "always" : "generated";
+  settings = { ...settings, approvalMode };
+
+  const scopeChoice = await ctx.ui.select("Save settings", [
+    "All projects (recommended)",
+    "This project only",
+  ]);
+  if (!scopeChoice) return undefined;
+  const scope = scopeChoice.startsWith("All") ? "global" : "project";
+  const approved = await ctx.ui.confirm("Save workflow setup?", formatSettings(settings));
+  if (!approved) return undefined;
+
+  const path = saveWorkflowControlSettings(settings, cwd, scope);
+  saveModelTierConfig(toModelTierConfig(settings));
+  ctx.ui.notify(`Saved ${settings.profile} workflow profile to ${path}.`, "info");
+  return settings;
+}
+
+async function chooseProfile(ctx: ExtensionCommandContext): Promise<WorkflowProfileName | undefined> {
+  const labels = WORKFLOW_PROFILE_NAMES.map((profile) => PROFILE_LABELS[profile]);
+  const selected = await ctx.ui.select("Workflow profile", labels);
+  return WORKFLOW_PROFILE_NAMES[labels.indexOf(selected ?? "")];
+}
+
+async function customizeRoutes(
+  settings: WorkflowControlSettings,
+  candidates: WorkflowModelCandidate[],
+  ctx: ExtensionCommandContext,
+  customizeLimits = false,
+): Promise<WorkflowControlSettings | undefined> {
+  const fallback = Object.values(settings.routes).map((route) => route.model);
+  const modelSpecs = [...new Set([...candidates.map((model) => model.spec), ...fallback])];
+  const labels = modelSpecs.map((spec) => {
+    const candidate = candidates.find((model) => model.spec === spec);
+    return candidate ? `${spec} — ${candidate.name}` : spec;
+  });
+  const routes = { ...settings.routes };
+
+  for (const role of WORKFLOW_ROLES) {
+    const current = settings.routes[role];
+    const selected = await ctx.ui.select(`${capitalize(role)} model`, labels);
+    const selectedIndex = labels.indexOf(selected ?? "");
+    if (selectedIndex < 0) return undefined;
+    const thinkingLabels = WORKFLOW_THINKING_LEVELS.map((level) =>
+      level === current.thinking ? `${level} (current)` : level,
+    );
+    const selectedThinking = await ctx.ui.select(`${capitalize(role)} effort`, thinkingLabels);
+    if (!selectedThinking) return undefined;
+    routes[role] = {
+      model: modelSpecs[selectedIndex],
+      thinking: selectedThinking.replace(" (current)", "") as WorkflowThinkingLevel,
+    };
+  }
+
+  return { ...settings, profile: customizeLimits ? "custom" : settings.profile, routes };
+}
+
+async function requireWorkflowApproval(
+  ctx: ExtensionContext,
+  preview: ReturnType<typeof createWorkflowPreview>,
+  required: boolean,
+): Promise<void> {
+  if (!required) return;
+  if (!ctx.hasUI) {
+    throw new Error("This workflow requires interactive approval. Run it from Pi's TUI or RPC mode.");
+  }
+  const approved = await ctx.ui.confirm(`Run workflow “${preview.name}”?`, formatWorkflowApproval(preview));
+  if (!approved) throw new Error("Workflow cancelled by the user before execution.");
+}
+
+function requireTrustedProject(ctx: ExtensionContext): void {
+  if (!ctx.isProjectTrusted()) {
+    throw new Error("Workflow execution is disabled because this project is not trusted.");
+  }
+}
+
+function requireConfiguredSettings(cwd: string): WorkflowControlSettings {
+  const settings = loadWorkflowControlSettings(cwd);
+  if (!settings) throw new Error("Workflow model roles are not configured. Run /workflow setup first.");
+  return settings;
+}
+
+function assertConfiguredModels(settings: WorkflowControlSettings, candidates: WorkflowModelCandidate[]): void {
+  if (!candidates.length) return;
+  const available = new Set(candidates.map((model) => model.spec));
+  const missing = WORKFLOW_ROLES.filter((role) => !available.has(settings.routes[role].model));
+  if (missing.length) {
+    throw new Error(`Workflow model routes are unavailable for ${missing.join(", ")}. Run /workflow setup again.`);
+  }
+}
+
+async function showSavedWorkflows(pi: ExtensionAPI, cwd: string): Promise<void> {
+  const workflows = discoverWorkflowFiles(cwd);
+  if (!workflows.length) {
+    await print(pi, "No saved workflows. Add project files under .pi/workflows/*.js or personal files under ~/.pi/workflows/saved/*.js.");
+    return;
+  }
+  await print(pi, ["Saved workflows:", ...workflows.map((workflow) => `  ${workflowLabel(workflow)}\n    ${workflow.path}`)].join("\n"));
+}
+
+async function showRuns(pi: ExtensionAPI, manager: WorkflowManager, activeOnly: boolean): Promise<void> {
+  const runs = manager
+    .listRuns()
+    .filter((run) => !activeOnly || run.status === "running" || run.status === "paused");
+  if (!runs.length) {
+    await print(pi, activeOnly ? "No active workflows." : "No workflow history yet.");
+    return;
+  }
+  await print(
+    pi,
+    [
+      activeOnly ? "Active workflows:" : "Workflow history:",
+      ...runs.map((run) => {
+        const done = run.agents.filter((agent) => agent.status === "done").length;
+        return `  ${run.runId}  ${run.workflowName}  ${run.status}  ${done}/${run.agents.length} agents`;
+      }),
+    ].join("\n"),
+  );
+}
+
+async function showRunStatus(pi: ExtensionAPI, manager: WorkflowManager, id?: string): Promise<void> {
+  if (!id) return print(pi, "Usage: /workflow status <runId>");
+  const run = manager.listRuns().find((candidate) => candidate.runId === id);
+  if (!run) return print(pi, `No workflow run "${id}".`);
+  const lines = [
+    `${run.workflowName} (${run.runId}) — ${run.status}`,
+    run.snapshot.currentPhase ? `Phase: ${run.snapshot.currentPhase}` : "",
+    ...run.agents.map(
+      (agent) => `  ${agent.status.padEnd(7)} ${agent.label}${agent.cached ? " (cached)" : ""}`,
+    ),
+  ].filter(Boolean);
+  await print(pi, lines.join("\n"));
+}
+
+async function showSettings(pi: ExtensionAPI, cwd: string): Promise<void> {
+  const settings = loadWorkflowControlSettings(cwd);
+  await print(pi, settings ? formatSettings(settings) : "Workflow is not configured. Run /workflow setup.");
+}
+
+function formatSettings(settings: WorkflowControlSettings): string {
+  return [
+    `Profile: ${settings.profile}`,
+    `Scale: ${settings.maxAgents} agents, ${settings.concurrency} concurrent`,
+    `Approval: ${settings.approvalMode === "always" ? "every workflow" : "generated workflows"}`,
+    ...WORKFLOW_ROLES.map((role) => `${capitalize(role)}: ${routeSpec(settings.routes[role])}`),
+  ].join("\n");
+}
+
+function notifyControl(
+  ctx: ExtensionCommandContext,
+  id: string | undefined,
+  action: string,
+  operation: (runId: string) => boolean,
+): void {
+  if (!id) return ctx.ui.notify(`Usage: /workflow ${action} <runId>`, "warning");
+  const changed = operation(id);
+  ctx.ui.notify(changed ? `${capitalize(action)}d ${id}.` : `Cannot ${action} ${id}.`, changed ? "info" : "warning");
+}
+
+async function resumeRun(manager: WorkflowManager, id: string | undefined, ctx: ExtensionCommandContext): Promise<void> {
+  if (!id) return ctx.ui.notify("Usage: /workflow resume <runId>", "warning");
+  const resumed = await manager.resume(id);
+  ctx.ui.notify(resumed ? `Resumed ${id}.` : `Cannot resume ${id}.`, resumed ? "info" : "warning");
+}
+
+async function askInteger(
+  ctx: ExtensionCommandContext,
+  title: string,
+  current: number,
+  min: number,
+  max: number,
+): Promise<number | undefined> {
+  const value = await ctx.ui.input(title, String(current));
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    ctx.ui.notify(`Enter a whole number from ${min} to ${max}.`, "error");
+    return undefined;
+  }
+  return parsed;
+}
+
+function normalizeProfile(value: string | undefined): WorkflowProfileName | undefined {
+  return value && WORKFLOW_PROFILE_NAMES.includes(value as WorkflowProfileName)
+    ? (value as WorkflowProfileName)
+    : undefined;
+}
+
+function workflowLabel(workflow: SavedWorkflowFile): string {
+  return `${workflow.id} — ${workflow.description} [${workflow.location}]`;
+}
+
+function capitalize(value: string): string {
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+}
+
+function print(pi: ExtensionAPI, content: string): Promise<void> {
+  return Promise.resolve(pi.sendMessage({ customType: "workflow", content, display: true })).then(() => {});
+}

--- a/extensions/workflow/index.ts
+++ b/extensions/workflow/index.ts
@@ -1,4 +1,9 @@
-import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+  SettingsManager,
+  type ExtensionAPI,
+  type ExtensionCommandContext,
+  type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import {
   buildForcedWorkflowPrompt,
   createWorkflowTool,
@@ -14,6 +19,7 @@ import {
 import { discoverWorkflowFiles, loadWorkflowFile } from "./discovery.js";
 import {
   routeSpec,
+  scopeModelCandidates,
   suggestWorkflowSettings,
   toModelCandidates,
   toModelTierConfig,
@@ -32,6 +38,7 @@ import {
   type WorkflowRole,
   type WorkflowThinkingLevel,
 } from "./types.js";
+import { WorkflowModelSelector } from "./model-selector.js";
 import { installWorkflowResultDelivery, installWorkflowTaskPanel } from "./ui.js";
 
 const USAGE = [
@@ -313,8 +320,15 @@ async function setupWorkflow(
     ctx.ui.notify("Workflow setup requires interactive mode.", "error");
     return undefined;
   }
-  const candidates = toModelCandidates(ctx.modelRegistry.getAvailable());
   const currentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+  const available = [...ctx.modelRegistry.getAvailable()];
+  if (ctx.model && !available.some((model) => `${model.provider}/${model.id}` === currentModel)) {
+    available.unshift(ctx.model);
+  }
+  const configuredScope = SettingsManager.create(cwd, undefined, {
+    projectTrusted: ctx.isProjectTrusted(),
+  }).getEnabledModels();
+  const candidates = scopeModelCandidates(toModelCandidates(available), configuredScope, currentModel);
   if (!candidates.length && !currentModel) {
     ctx.ui.notify("No authenticated models are available.", "error");
     return undefined;
@@ -389,31 +403,50 @@ async function customizeRoutes(
   ctx: ExtensionCommandContext,
   customizeLimits = false,
 ): Promise<WorkflowControlSettings | undefined> {
-  const fallback = Object.values(settings.routes).map((route) => route.model);
-  const modelSpecs = [...new Set([...candidates.map((model) => model.spec), ...fallback])];
-  const labels = modelSpecs.map((spec) => {
-    const candidate = candidates.find((model) => model.spec === spec);
-    return candidate ? `${spec} — ${candidate.name}` : spec;
-  });
   const routes = { ...settings.routes };
 
   for (const role of WORKFLOW_ROLES) {
     const current = settings.routes[role];
-    const selected = await ctx.ui.select(`${capitalize(role)} model`, labels);
-    const selectedIndex = labels.indexOf(selected ?? "");
-    if (selectedIndex < 0) return undefined;
+    const selectedModel = await selectWorkflowModel(ctx, `${capitalize(role)} model`, candidates, current.model);
+    if (!selectedModel) return undefined;
     const thinkingLabels = WORKFLOW_THINKING_LEVELS.map((level) =>
       level === current.thinking ? `${level} (current)` : level,
     );
     const selectedThinking = await ctx.ui.select(`${capitalize(role)} effort`, thinkingLabels);
     if (!selectedThinking) return undefined;
     routes[role] = {
-      model: modelSpecs[selectedIndex],
+      model: selectedModel,
       thinking: selectedThinking.replace(" (current)", "") as WorkflowThinkingLevel,
     };
   }
 
   return { ...settings, profile: customizeLimits ? "custom" : settings.profile, routes };
+}
+
+async function selectWorkflowModel(
+  ctx: ExtensionCommandContext,
+  title: string,
+  candidates: readonly WorkflowModelCandidate[],
+  currentSpec: string,
+): Promise<string | undefined> {
+  if (ctx.mode !== "tui") {
+    const labels = candidates.map((model) => `${model.spec} — ${model.name}`);
+    const selected = await ctx.ui.select(title, labels);
+    const index = labels.indexOf(selected ?? "");
+    return candidates[index]?.spec;
+  }
+  return ctx.ui.custom<string | undefined>(
+    (tui, theme, _keybindings, done) =>
+      new WorkflowModelSelector(
+        tui,
+        theme,
+        title,
+        candidates,
+        currentSpec,
+        (model) => done(model.spec),
+        () => done(undefined),
+      ),
+  );
 }
 
 async function requireWorkflowApproval(

--- a/extensions/workflow/index.ts
+++ b/extensions/workflow/index.ts
@@ -39,6 +39,7 @@ import {
   type WorkflowThinkingLevel,
 } from "./types.js";
 import { WorkflowModelSelector } from "./model-selector.js";
+import { openWorkflowRunBrowser } from "./run-browser.js";
 import { installWorkflowResultDelivery, installWorkflowTaskPanel } from "./ui.js";
 
 const USAGE = [
@@ -47,7 +48,8 @@ const USAGE = [
   "  /workflow run <prompt>            generate and run a workflow",
   "  /workflow saved <name> [json]     run a saved JavaScript workflow",
   "  /workflow list                    list saved workflow files",
-  "  /workflow active | history        inspect runs",
+  "  /workflow runs                    open the interactive run browser",
+  "  /workflow active | history        open runs with a status filter",
   "  /workflow status <id>             inspect one run",
   "  /workflow pause|resume|stop <id>  control a run",
   "  /workflow remove <id>             delete a persisted run",
@@ -153,14 +155,21 @@ function registerWorkflowCommand(
         case "list":
           await showSavedWorkflows(pi, cwd);
           return;
+        case "runs":
+          if (ctx.hasUI) await openWorkflowRunBrowser(manager, cwd, ctx);
+          else await showRuns(pi, manager, false);
+          return;
         case "active":
-          await showRuns(pi, manager, true);
+          if (ctx.hasUI) await openWorkflowRunBrowser(manager, cwd, ctx, { initialFilter: "active" });
+          else await showRuns(pi, manager, true);
           return;
         case "history":
-          await showRuns(pi, manager, false);
+          if (ctx.hasUI) await openWorkflowRunBrowser(manager, cwd, ctx);
+          else await showRuns(pi, manager, false);
           return;
         case "status":
-          await showRunStatus(pi, manager, rest[0]);
+          if (ctx.hasUI && rest[0]) await openWorkflowRunBrowser(manager, cwd, ctx, { initialRunId: rest[0] });
+          else await showRunStatus(pi, manager, rest[0]);
           return;
         case "pause":
           notifyControl(ctx, rest[0], "pause", (id) => manager.pause(id));
@@ -203,21 +212,14 @@ async function openWorkflowHub(
     await print(pi, USAGE);
     return;
   }
-  const action = await ctx.ui.select("Workflow", [
-    "Run a dynamic workflow",
-    "Run a saved workflow",
-    "Active runs",
-    "Run history",
-    "Setup model profile",
-    "Show settings",
-  ]);
+  const action = await openWorkflowRunBrowser(manager, cwd, ctx);
   switch (action) {
-    case "Run a dynamic workflow": {
+    case "new": {
       const prompt = await ctx.ui.editor("What should the workflow accomplish?", "");
       if (prompt?.trim()) await runGeneratedWorkflow(pi, cwd, toolName, prompt.trim(), ctx);
       return;
     }
-    case "Run a saved workflow": {
+    case "saved": {
       const workflows = discoverWorkflowFiles(cwd);
       if (!workflows.length) return ctx.ui.notify("No saved .js workflows found.", "info");
       const labels = workflows.map((workflow) => workflowLabel(workflow));
@@ -226,16 +228,10 @@ async function openWorkflowHub(
       if (workflow) await runSavedWorkflow(manager, cwd, workflow.id, "", ctx);
       return;
     }
-    case "Active runs":
-      await showRuns(pi, manager, true);
-      return;
-    case "Run history":
-      await showRuns(pi, manager, false);
-      return;
-    case "Setup model profile":
+    case "setup":
       await setupWorkflow(cwd, ctx);
       return;
-    case "Show settings":
+    case "settings":
       await showSettings(pi, cwd);
       return;
   }
@@ -494,7 +490,7 @@ async function showSavedWorkflows(pi: ExtensionAPI, cwd: string): Promise<void> 
 
 async function showRuns(pi: ExtensionAPI, manager: WorkflowManager, activeOnly: boolean): Promise<void> {
   const runs = manager
-    .listRuns()
+    .listAllRuns()
     .filter((run) => !activeOnly || run.status === "running" || run.status === "paused");
   if (!runs.length) {
     await print(pi, activeOnly ? "No active workflows." : "No workflow history yet.");
@@ -514,7 +510,7 @@ async function showRuns(pi: ExtensionAPI, manager: WorkflowManager, activeOnly: 
 
 async function showRunStatus(pi: ExtensionAPI, manager: WorkflowManager, id?: string): Promise<void> {
   if (!id) return print(pi, "Usage: /workflow status <runId>");
-  const run = manager.listRuns().find((candidate) => candidate.runId === id);
+  const run = manager.listAllRuns().find((candidate) => candidate.runId === id);
   if (!run) return print(pi, `No workflow run "${id}".`);
   const lines = [
     `${run.workflowName} (${run.runId}) — ${run.status}`,

--- a/extensions/workflow/model-selector.ts
+++ b/extensions/workflow/model-selector.ts
@@ -1,0 +1,124 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import {
+  Container,
+  fuzzyFilter,
+  getKeybindings,
+  Input,
+  Spacer,
+  Text,
+  type Focusable,
+  type TUI,
+} from "@earendil-works/pi-tui";
+import type { WorkflowModelCandidate } from "./types.js";
+
+const MAX_VISIBLE_MODELS = 9;
+
+export function filterWorkflowModels(
+  models: readonly WorkflowModelCandidate[],
+  query: string,
+): WorkflowModelCandidate[] {
+  const trimmed = query.trim();
+  if (!trimmed) return [...models];
+  return fuzzyFilter([...models], trimmed, (model) => `${model.spec} ${model.name} ${model.provider}`);
+}
+
+export class WorkflowModelSelector extends Container implements Focusable {
+  private readonly input = new Input();
+  private readonly list = new Container();
+  private filtered: WorkflowModelCandidate[];
+  private selectedIndex: number;
+  private _focused = false;
+
+  get focused(): boolean {
+    return this._focused;
+  }
+
+  set focused(value: boolean) {
+    this._focused = value;
+    this.input.focused = value;
+  }
+
+  constructor(
+    private readonly tui: TUI,
+    private readonly theme: Theme,
+    title: string,
+    private readonly models: readonly WorkflowModelCandidate[],
+    private readonly currentSpec: string,
+    private readonly onSelect: (model: WorkflowModelCandidate) => void,
+    private readonly onCancel: () => void,
+  ) {
+    super();
+    this.filtered = [...models];
+    this.selectedIndex = Math.max(0, this.filtered.findIndex((model) => model.spec === currentSpec));
+
+    this.addChild(new Text(theme.fg("accent", title), 1, 0));
+    this.addChild(new Text(theme.fg("muted", "Type to filter models"), 1, 0));
+    this.addChild(this.input);
+    this.addChild(new Spacer(1));
+    this.addChild(this.list);
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(theme.fg("muted", "↑↓ navigate  enter select  escape cancel"), 1, 0));
+
+    this.input.onSubmit = () => this.selectCurrent();
+    this.updateList();
+  }
+
+  handleInput(data: string): void {
+    const keybindings = getKeybindings();
+    if (keybindings.matches(data, "tui.select.up")) {
+      if (this.filtered.length) {
+        this.selectedIndex = this.selectedIndex === 0 ? this.filtered.length - 1 : this.selectedIndex - 1;
+        this.updateList();
+      }
+    } else if (keybindings.matches(data, "tui.select.down")) {
+      if (this.filtered.length) {
+        this.selectedIndex = this.selectedIndex === this.filtered.length - 1 ? 0 : this.selectedIndex + 1;
+        this.updateList();
+      }
+    } else if (keybindings.matches(data, "tui.select.confirm")) {
+      this.selectCurrent();
+    } else if (keybindings.matches(data, "tui.select.cancel")) {
+      this.onCancel();
+    } else {
+      this.input.handleInput(data);
+      this.filtered = filterWorkflowModels(this.models, this.input.getValue());
+      this.selectedIndex = 0;
+      this.updateList();
+    }
+    this.tui.requestRender();
+  }
+
+  private selectCurrent(): void {
+    const selected = this.filtered[this.selectedIndex];
+    if (selected) this.onSelect(selected);
+  }
+
+  private updateList(): void {
+    this.list.clear();
+    const start = Math.max(
+      0,
+      Math.min(
+        this.selectedIndex - Math.floor(MAX_VISIBLE_MODELS / 2),
+        this.filtered.length - MAX_VISIBLE_MODELS,
+      ),
+    );
+    const end = Math.min(start + MAX_VISIBLE_MODELS, this.filtered.length);
+    for (let index = start; index < end; index += 1) {
+      const model = this.filtered[index];
+      if (!model) continue;
+      const selected = index === this.selectedIndex;
+      const marker = selected ? this.theme.fg("accent", "→") : " ";
+      const spec = selected ? this.theme.fg("accent", model.spec) : model.spec;
+      const current = model.spec === this.currentSpec ? this.theme.fg("success", " ✓") : "";
+      this.list.addChild(new Text(`${marker} ${spec}${current}`, 1, 0));
+      if (selected) this.list.addChild(new Text(this.theme.fg("muted", `    ${model.name}`), 1, 0));
+    }
+    if (!this.filtered.length) {
+      this.list.addChild(new Text(this.theme.fg("warning", "  No matching models"), 1, 0));
+    } else if (start > 0 || end < this.filtered.length) {
+      this.list.addChild(
+        new Text(this.theme.fg("muted", `  ${this.selectedIndex + 1}/${this.filtered.length}`), 1, 0),
+      );
+    }
+  }
+}

--- a/extensions/workflow/preview.ts
+++ b/extensions/workflow/preview.ts
@@ -1,0 +1,90 @@
+import { WORKFLOW_ROLES, type WorkflowControlSettings, type WorkflowPreview } from "./types.js";
+import { routeSpec } from "./profiles.js";
+import { parseWorkflowScript, type WorkflowToolInput } from "./runtime.js";
+
+export function createWorkflowPreview(
+  script: string,
+  settings: WorkflowControlSettings,
+  source: "generated" | "saved",
+  requested: Pick<WorkflowToolInput, "concurrency" | "maxAgents"> = {},
+): WorkflowPreview {
+  const { meta } = parseWorkflowScript(script);
+  return {
+    name: meta.name,
+    description: meta.description,
+    phases: meta.phases?.map((phase) => phase.title) ?? [],
+    staticAgentCalls: countStaticAgentCalls(script),
+    explicitModels: collectStringOptions(script, "model"),
+    explicitTools: collectTools(script),
+    profile: settings.profile,
+    routes: settings.routes,
+    concurrency: clamp(requested.concurrency, settings.concurrency),
+    maxAgents: clamp(requested.maxAgents, settings.maxAgents),
+    source,
+  };
+}
+
+export function applyWorkflowLimits(
+  input: WorkflowToolInput,
+  settings: WorkflowControlSettings,
+): WorkflowToolInput {
+  return {
+    ...input,
+    concurrency: clamp(input.concurrency, settings.concurrency),
+    maxAgents: clamp(input.maxAgents, settings.maxAgents),
+  };
+}
+
+export function formatWorkflowApproval(preview: WorkflowPreview): string {
+  const lines = [
+    `${preview.name} — ${preview.description}`,
+    "",
+    `Source: ${preview.source}`,
+    `Profile: ${preview.profile}`,
+    `Phases: ${preview.phases.length ? preview.phases.join(" → ") : "not declared"}`,
+    `Scale cap: ${preview.maxAgents} agents, ${preview.concurrency} concurrent`,
+    `Static agent() call sites: ${preview.staticAgentCalls || "dynamic/unknown"}`,
+    "",
+    "Model routes:",
+    ...WORKFLOW_ROLES.map((role) => `  ${role}: ${routeSpec(preview.routes[role])}`),
+    "",
+    preview.explicitModels.length
+      ? `Explicit model overrides: ${preview.explicitModels.join(", ")}`
+      : "Explicit model overrides: none detected",
+    preview.explicitTools.length
+      ? `Explicit tool allowlists: ${preview.explicitTools.join(", ")}`
+      : "Tools: default coding tools (repository writes are possible)",
+    "",
+    "Security: this trusted JavaScript runs in the upstream in-process VM. The VM is a determinism boundary, not a security sandbox.",
+  ];
+  return lines.join("\n");
+}
+
+function countStaticAgentCalls(script: string): number {
+  return script.match(/\bagent\s*\(/g)?.length ?? 0;
+}
+
+function collectStringOptions(script: string, key: string): string[] {
+  const values = new Set<string>();
+  const pattern = new RegExp(`\\b${key}\\s*:\\s*(["'])(.*?)\\1`, "g");
+  for (const match of script.matchAll(pattern)) {
+    if (match[2]) values.add(match[2]);
+  }
+  return [...values];
+}
+
+function collectTools(script: string): string[] {
+  const values = new Set<string>();
+  const arrays = script.matchAll(/\btools\s*:\s*\[([^\]]*)\]/g);
+  for (const array of arrays) {
+    for (const match of array[1].matchAll(/(["'])(.*?)\1/g)) {
+      if (match[2]) values.add(match[2]);
+    }
+  }
+  return [...values];
+}
+
+function clamp(requested: number | undefined, configured: number): number {
+  if (typeof requested !== "number" || !Number.isFinite(requested) || requested < 1) return configured;
+  return Math.min(Math.floor(requested), configured);
+}

--- a/extensions/workflow/preview.ts
+++ b/extensions/workflow/preview.ts
@@ -8,12 +8,17 @@ export function createWorkflowPreview(
   source: "generated" | "saved",
   requested: Pick<WorkflowToolInput, "concurrency" | "maxAgents"> = {},
 ): WorkflowPreview {
-  const { meta } = parseWorkflowScript(script);
+  const { meta, body } = parseWorkflowScript(script);
+  const executableAgentCalls = countStaticAgentCalls(body);
+  if (!executableAgentCalls) {
+    throw new Error("Workflow preflight failed: the executable workflow body does not call agent().");
+  }
   return {
     name: meta.name,
     description: meta.description,
+    script,
     phases: meta.phases?.map((phase) => phase.title) ?? [],
-    staticAgentCalls: countStaticAgentCalls(script),
+    staticAgentCalls: executableAgentCalls,
     explicitModels: collectStringOptions(script, "model"),
     explicitTools: collectTools(script),
     profile: settings.profile,

--- a/extensions/workflow/profiles.ts
+++ b/extensions/workflow/profiles.ts
@@ -21,6 +21,37 @@ export function toModelCandidates(models: readonly Model<any>[]): WorkflowModelC
   }));
 }
 
+export function scopeModelCandidates(
+  models: readonly WorkflowModelCandidate[],
+  patterns: readonly string[] | undefined,
+  currentModelSpec?: string,
+): WorkflowModelCandidate[] {
+  const unique = new Map(models.map((model) => [model.spec, model]));
+  if (!patterns?.length) return [...unique.values()];
+
+  const scoped: WorkflowModelCandidate[] = [];
+  const seen = new Set<string>();
+  for (const rawPattern of patterns) {
+    const pattern = stripThinkingSuffix(rawPattern.trim());
+    const candidates = [...unique.values()];
+    const exact = candidates.filter((model) => exactModelPattern(model, pattern));
+    const matches = exact.length
+      ? exact
+      : pattern.includes("*")
+        ? candidates.filter((model) => matchesWildcardPattern(model, pattern))
+        : candidates.filter((model) => matchesFuzzyPattern(model, pattern)).slice(0, 1);
+    for (const model of matches) {
+      if (seen.has(model.spec)) continue;
+      scoped.push(model);
+      seen.add(model.spec);
+    }
+  }
+  if (currentModelSpec && unique.has(currentModelSpec) && !seen.has(currentModelSpec)) {
+    scoped.unshift(unique.get(currentModelSpec)!);
+  }
+  return scoped.length ? scoped : [...unique.values()];
+}
+
 export function suggestWorkflowSettings(
   profile: Exclude<WorkflowProfileName, "custom">,
   models: readonly WorkflowModelCandidate[],
@@ -88,6 +119,33 @@ function differentProviderModel(
 
 function route(model: string, thinking: WorkflowThinkingLevel): WorkflowRoleRoute {
   return { model, thinking };
+}
+
+function stripThinkingSuffix(pattern: string): string {
+  const match = pattern.match(/:(off|minimal|low|medium|high|xhigh|max)$/i);
+  return match ? pattern.slice(0, -match[0].length) : pattern;
+}
+
+function exactModelPattern(model: WorkflowModelCandidate, rawPattern: string): boolean {
+  const pattern = rawPattern.toLowerCase();
+  const spec = model.spec.toLowerCase();
+  const id = spec.slice(spec.indexOf("/") + 1);
+  return pattern === spec || pattern === id;
+}
+
+function matchesWildcardPattern(model: WorkflowModelCandidate, rawPattern: string): boolean {
+  const source = rawPattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*");
+  const wildcard = new RegExp(`^${source}$`, "i");
+  const spec = model.spec.toLowerCase();
+  const id = spec.slice(spec.indexOf("/") + 1);
+  return wildcard.test(spec) || wildcard.test(id);
+}
+
+function matchesFuzzyPattern(model: WorkflowModelCandidate, rawPattern: string): boolean {
+  const pattern = rawPattern.toLowerCase();
+  const spec = model.spec.toLowerCase();
+  const search = `${spec} ${model.name}`.toLowerCase();
+  return search.includes(pattern);
 }
 
 export function routeSpec(route: WorkflowRoleRoute): string {

--- a/extensions/workflow/profiles.ts
+++ b/extensions/workflow/profiles.ts
@@ -1,0 +1,117 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { profileLimits } from "./config.js";
+import type { ModelTierConfig } from "./runtime.js";
+import {
+  WORKFLOW_ROLES,
+  type WorkflowControlSettings,
+  type WorkflowModelCandidate,
+  type WorkflowProfileName,
+  type WorkflowRole,
+  type WorkflowRoleRoute,
+  type WorkflowThinkingLevel,
+} from "./types.js";
+
+export function toModelCandidates(models: readonly Model<any>[]): WorkflowModelCandidate[] {
+  return models.map((model) => ({
+    spec: `${model.provider}/${model.id}`,
+    provider: model.provider,
+    name: model.name,
+    costOutput: model.cost?.output ?? 0,
+    contextWindow: model.contextWindow ?? 0,
+  }));
+}
+
+export function suggestWorkflowSettings(
+  profile: Exclude<WorkflowProfileName, "custom">,
+  models: readonly WorkflowModelCandidate[],
+  currentModelSpec?: string,
+): WorkflowControlSettings {
+  if (!models.length && !currentModelSpec) {
+    throw new Error("No authenticated models are available for workflow setup.");
+  }
+
+  const ranked = rankModels(models);
+  const fallback = currentModelSpec ?? ranked[ranked.length - 1]?.spec;
+  if (!fallback) throw new Error("No model is available for workflow setup.");
+
+  const smallest = ranked[0]?.spec ?? fallback;
+  const strongest = ranked[ranked.length - 1]?.spec ?? fallback;
+  const middle = ranked[Math.floor(ranked.length / 2)]?.spec ?? fallback;
+  const worker = profile === "lean" ? middle : profile === "deep" ? strongest : currentModelSpec ?? middle;
+  const reviewer = differentProviderModel(ranked, worker)?.spec ?? strongest;
+  const limits = profileLimits(profile);
+
+  const routes: Record<WorkflowRole, WorkflowRoleRoute> = {
+    scout: route(smallest, profile === "deep" ? "medium" : "low"),
+    worker: route(worker, profile === "lean" ? "low" : profile === "deep" ? "high" : "medium"),
+    reviewer: route(reviewer, profile === "deep" ? "xhigh" : profile === "lean" ? "medium" : "high"),
+    synthesizer: route(strongest, profile === "deep" ? "max" : "high"),
+  };
+
+  return {
+    version: 1,
+    profile,
+    routes,
+    concurrency: limits.concurrency,
+    maxAgents: limits.maxAgents,
+    approvalMode: "always",
+  };
+}
+
+export function rankModels(models: readonly WorkflowModelCandidate[]): WorkflowModelCandidate[] {
+  const priced = models.filter((model) => model.costOutput > 0).map((model) => model.costOutput);
+  const min = priced.length ? Math.min(...priced) : 0;
+  const max = priced.length ? Math.max(...priced) : 0;
+  const midpoint = priced.length ? (min + max) / 2 : 0;
+
+  return models
+    .map((model, index) => ({ model, index, score: modelScore(model, min, max, midpoint) }))
+    .sort((a, b) => a.score - b.score || a.model.contextWindow - b.model.contextWindow || a.index - b.index)
+    .map(({ model }) => model);
+}
+
+function modelScore(model: WorkflowModelCandidate, min: number, max: number, midpoint: number): number {
+  if (model.costOutput > 0) return model.costOutput;
+  const value = `${model.spec} ${model.name}`.toLowerCase();
+  if (/mini|flash|haiku|nano|small/.test(value)) return min;
+  if (/opus|pro|ultra|large|plus/.test(value)) return max;
+  return midpoint;
+}
+
+function differentProviderModel(
+  ranked: readonly WorkflowModelCandidate[],
+  workerSpec: string,
+): WorkflowModelCandidate | undefined {
+  const workerProvider = workerSpec.split("/", 1)[0];
+  return [...ranked].reverse().find((model) => model.provider !== workerProvider);
+}
+
+function route(model: string, thinking: WorkflowThinkingLevel): WorkflowRoleRoute {
+  return { model, thinking };
+}
+
+export function routeSpec(route: WorkflowRoleRoute): string {
+  return `${route.model}:${route.thinking}`;
+}
+
+export function toModelTierConfig(settings: WorkflowControlSettings): ModelTierConfig {
+  const tiers: Record<string, string> = {};
+  for (const role of WORKFLOW_ROLES) tiers[role] = routeSpec(settings.routes[role]);
+  // Compatibility aliases for upstream-generated and older saved workflows.
+  tiers.small = tiers.scout;
+  tiers.medium = tiers.worker;
+  tiers.big = tiers.synthesizer;
+  return { tiers };
+}
+
+export function workflowRoleGuideline(settings: WorkflowControlSettings): string {
+  const routes = WORKFLOW_ROLES.map(
+    (role) => `${role}=${routeSpec(settings.routes[role])}`,
+  ).join(", ");
+  return [
+    `This installation uses the ${settings.profile} workflow profile (${routes}).`,
+    "Tag every agent with one of these semantic tiers: scout for cheap discovery, worker for implementation/analysis, reviewer for independent criticism, synthesizer for final integration.",
+    "Use the literal role in opts.tier, for example { tier: 'scout' } or { tier: 'reviewer' }; small/medium/big remain compatibility aliases only.",
+    `Keep the generated workflow within ${settings.maxAgents} total agents and ${settings.concurrency} concurrent agents.`,
+  ].join(" ");
+}

--- a/extensions/workflow/run-browser.ts
+++ b/extensions/workflow/run-browser.ts
@@ -1,0 +1,563 @@
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { copyToClipboard, getMarkdownTheme, type ExtensionCommandContext, type Theme } from "@earendil-works/pi-coding-agent";
+import { Key, Markdown, matchesKey, truncateToWidth, visibleWidth, type TUI } from "@earendil-works/pi-tui";
+import type { PersistedRunState, WorkflowAgentSnapshot, WorkflowManager } from "./runtime.js";
+
+type RunFilter = "all" | "active" | "completed" | "failed";
+type DetailTab = "result" | "progress" | "agents" | "workflow";
+type Screen = "runs" | "detail" | "agent";
+
+export type WorkflowBrowserExit = "new" | "saved" | "setup" | "settings" | null;
+
+export interface WorkflowRunBrowserOptions {
+  initialFilter?: RunFilter;
+  initialRunId?: string;
+}
+
+const FILTERS: RunFilter[] = ["all", "active", "completed", "failed"];
+const TABS: DetailTab[] = ["result", "progress", "agents", "workflow"];
+
+export async function openWorkflowRunBrowser(
+  manager: WorkflowManager,
+  cwd: string,
+  ctx: ExtensionCommandContext,
+  options: WorkflowRunBrowserOptions = {},
+): Promise<WorkflowBrowserExit> {
+  if (!ctx.hasUI) return null;
+  return ctx.ui.custom<WorkflowBrowserExit>((tui, theme, _kb, done) =>
+    new WorkflowRunBrowser(tui, theme, manager, cwd, options, done, (message, level = "info") => {
+      ctx.ui.notify(message, level);
+    }),
+  );
+}
+
+export function workflowResultMarkdown(run: PersistedRunState): string {
+  const value = run.result?.result ?? run.snapshot.result;
+  if (value === undefined || value === null) {
+    if (run.error) return `# Workflow failed\n\n${run.error}`;
+    return run.status === "completed" ? "_The workflow completed without a result._" : "_No result yet._";
+  }
+  if (typeof value === "string") return value;
+  if (typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    for (const key of ["report", "markdown", "content", "text", "summary"]) {
+      if (typeof record[key] === "string" && record[key].trim()) return record[key] as string;
+    }
+  }
+  return `# Workflow result\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
+}
+
+export function formatWorkflowRunSummary(run: PersistedRunState): string {
+  const duration = run.result?.durationMs ?? run.snapshot.durationMs ?? elapsedMs(run.startedAt, run.updatedAt);
+  return [
+    `Status: ${run.status}`,
+    `Agents: ${run.snapshot.doneCount}/${run.snapshot.agentCount}`,
+    `Duration: ${formatDuration(duration)}`,
+    `Tokens: ${formatTokens(run.snapshot.tokens)}`,
+    `Cost: $${run.snapshot.cost.toFixed(4)}`,
+  ].join(" · ");
+}
+
+export function exportWorkflowReport(
+  run: PersistedRunState,
+  cwd: string,
+  format: "markdown" | "html",
+  directory = workflowExportsDir(cwd),
+): string {
+  mkdirSync(directory, { recursive: true });
+  const extension = format === "html" ? "html" : "md";
+  const path = join(directory, `${run.runId}.${extension}`);
+  const content = format === "html" ? workflowReportHtml(run) : workflowReportFile(run);
+  writeFileSync(path, content, "utf8");
+  return path;
+}
+
+export function saveWorkflowScript(run: PersistedRunState, cwd: string): string {
+  const directory = join(cwd, ".pi", "workflows");
+  mkdirSync(directory, { recursive: true });
+  const slug = safeSlug(run.workflowName) || "workflow";
+  let path = join(directory, `${slug}.js`);
+  if (existsSync(path) && readFileSync(path, "utf8") !== run.script) {
+    path = join(directory, `${slug}-${run.runId.slice(-6)}.js`);
+  }
+  writeFileSync(path, `${run.script.trimEnd()}\n`, "utf8");
+  return path;
+}
+
+export class WorkflowRunBrowser {
+  private filter: RunFilter;
+  private screen: Screen;
+  private selectedRunId?: string;
+  private selectedAgentIndex = 0;
+  private selectedAgent?: WorkflowAgentSnapshot;
+  private tab: DetailTab = "result";
+  private scrollOffset = 0;
+  private totalLines = 0;
+  private viewHeight = 1;
+  private readonly events = ["progress", "agentStart", "agentEnd", "phase", "complete", "error", "paused", "stopped"];
+
+  constructor(
+    private readonly tui: TUI,
+    private readonly theme: Theme,
+    private readonly manager: WorkflowManager,
+    private readonly cwd: string,
+    options: WorkflowRunBrowserOptions,
+    private readonly done: (result: WorkflowBrowserExit) => void,
+    private readonly notify: (message: string, level?: "info" | "warning" | "error") => void,
+  ) {
+    this.filter = options.initialFilter ?? "all";
+    this.selectedRunId = options.initialRunId;
+    this.screen = options.initialRunId ? "detail" : "runs";
+    const selected = this.currentRun();
+    if (selected) this.tab = selected.status === "completed" ? "result" : "progress";
+    for (const event of this.events) this.manager.on(event, this.refresh);
+  }
+
+  dispose(): void {
+    for (const event of this.events) this.manager.off(event, this.refresh);
+  }
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    const height = Math.max(12, Math.floor((this.tui.terminal.rows || 24) * 0.8));
+    if (this.screen === "runs") return this.renderRuns(width, height);
+    if (this.screen === "agent") return this.renderAgent(width, height);
+    return this.renderDetail(width, height);
+  }
+
+  handleInput(data: string): void {
+    if (this.screen === "runs") return this.handleRunsInput(data);
+    if (this.screen === "agent") return this.handleAgentInput(data);
+    return this.handleDetailInput(data);
+  }
+
+  private readonly refresh = () => this.tui.requestRender();
+
+  private runs(): PersistedRunState[] {
+    const runs = this.manager.listAllRuns();
+    if (this.filter === "active") return runs.filter((run) => run.status === "running" || run.status === "paused");
+    if (this.filter === "completed") return runs.filter((run) => run.status === "completed");
+    if (this.filter === "failed") return runs.filter((run) => run.status === "failed" || run.status === "aborted");
+    return runs;
+  }
+
+  private currentRun(): PersistedRunState | undefined {
+    const runs = this.manager.listAllRuns();
+    const selected = runs.find((run) => run.runId === this.selectedRunId);
+    if (this.screen !== "runs" && this.selectedRunId) return selected;
+    return selected ?? this.runs()[0];
+  }
+
+  private renderRuns(width: number, height: number): string[] {
+    const runs = this.runs();
+    if (!runs.some((run) => run.runId === this.selectedRunId)) this.selectedRunId = runs[0]?.runId;
+    const selectedIndex = Math.max(0, runs.findIndex((run) => run.runId === this.selectedRunId));
+    const contentHeight = Math.max(4, height - 7);
+    const start = Math.max(0, Math.min(selectedIndex - Math.floor(contentHeight / 2), runs.length - contentHeight));
+    const visible = runs.slice(start, start + contentHeight);
+    const allRuns = this.manager.listAllRuns();
+    const active = allRuns.filter((run) => run.status === "running" || run.status === "paused").length;
+    const lines = [
+      this.theme.fg("accent", this.theme.bold(`Workflow runs · ${active} active · ${allRuns.length} total`)),
+      this.theme.fg("muted", `Filter: ${this.filter}  (f cycles)`),
+      "",
+    ];
+    if (!runs.length) {
+      lines.push(this.theme.fg("muted", "No workflow runs in this view."));
+    } else {
+      for (const run of visible) {
+        const selected = run.runId === this.selectedRunId;
+        const marker = selected ? this.theme.fg("accent", "→") : " ";
+        const status = statusLabel(this.theme, run.status);
+        const done = `${run.snapshot.doneCount}/${run.snapshot.agentCount}`;
+        const name = selected ? this.theme.fg("accent", run.workflowName) : run.workflowName;
+        const usage = `${formatTokens(run.snapshot.tokens)} tok · $${run.snapshot.cost.toFixed(2)}`;
+        lines.push(truncateToWidth(`${marker} ${status} ${name}  ${done} agents  ${usage}`, Math.max(10, width - 2)));
+        if (selected) lines.push(this.theme.fg("dim", `    ${run.runId}`));
+      }
+    }
+    while (lines.length < height - 3) lines.push("");
+    lines.push(this.theme.fg("dim", "↑↓ select · enter inspect · f filter"));
+    lines.push(this.theme.fg("dim", "n new · w saved · g setup · i settings · esc close"));
+    return frame(this.theme, lines, width);
+  }
+
+  private renderDetail(width: number, height: number): string[] {
+    const run = this.currentRun();
+    if (!run) {
+      this.screen = "runs";
+      return this.renderRuns(width, height);
+    }
+    this.selectedRunId = run.runId;
+    const innerWidth = Math.max(20, width - 4);
+    const contentHeight = Math.max(3, height - 9);
+    const tabs = TABS.map((tab) => tab === this.tab ? this.theme.fg("accent", `[${tab}]`) : this.theme.fg("muted", tab)).join("  ");
+    const lines = [
+      this.theme.fg("accent", this.theme.bold(run.workflowName)),
+      truncateToWidth(formatWorkflowRunSummary(run), innerWidth),
+      tabs,
+      "",
+    ];
+
+    if (this.tab === "agents") {
+      lines.push(...this.renderAgentList(run, innerWidth, contentHeight));
+      this.totalLines = run.agents.length;
+      this.viewHeight = contentHeight;
+    } else {
+      const markdown = new Markdown(this.tabMarkdown(run), 0, 0, getMarkdownTheme());
+      const rendered = markdown.render(innerWidth);
+      this.totalLines = rendered.length;
+      this.viewHeight = contentHeight;
+      this.clampScroll();
+      lines.push(...rendered.slice(this.scrollOffset, this.scrollOffset + contentHeight));
+    }
+    while (lines.length < height - 3) lines.push("");
+    const scroll = this.totalLines > this.viewHeight ? ` · ${this.scrollOffset + 1}-${Math.min(this.totalLines, this.scrollOffset + this.viewHeight)}/${this.totalLines}` : "";
+    lines.push(this.theme.fg("dim", `←→/tab views · ↑↓ scroll · enter agent · esc back${scroll}`));
+    lines.push(this.theme.fg("dim", "c copy · m Markdown · h HTML · o open HTML · s save workflow · p pause/resume · x stop"));
+    return frame(this.theme, lines, width);
+  }
+
+  private renderAgent(width: number, height: number): string[] {
+    const run = this.currentRun();
+    const agent = this.selectedAgent;
+    if (!run || !agent) {
+      this.screen = "detail";
+      return this.renderDetail(width, height);
+    }
+    const innerWidth = Math.max(20, width - 4);
+    const contentHeight = Math.max(3, height - 6);
+    const markdown = new Markdown(agentMarkdown(agent), 0, 0, getMarkdownTheme());
+    const rendered = markdown.render(innerWidth);
+    this.totalLines = rendered.length;
+    this.viewHeight = contentHeight;
+    this.clampScroll();
+    const lines = [
+      this.theme.fg("accent", this.theme.bold(`${agent.label} · ${agent.status}`)),
+      this.theme.fg("muted", `${agent.phase ?? "No phase"} · ${agent.model ?? "model pending"} · ${formatTokens(agent.tokens ?? 0)} tok · $${(agent.cost ?? 0).toFixed(4)}`),
+      "",
+      ...rendered.slice(this.scrollOffset, this.scrollOffset + contentHeight),
+    ];
+    while (lines.length < height - 2) lines.push("");
+    lines.push(this.theme.fg("dim", "↑↓/pgup/pgdn scroll · c copy result · esc agents"));
+    return frame(this.theme, lines, width);
+  }
+
+  private renderAgentList(run: PersistedRunState, width: number, height: number): string[] {
+    this.selectedAgentIndex = Math.min(this.selectedAgentIndex, Math.max(0, run.agents.length - 1));
+    if (!run.agents.length) return [this.theme.fg("muted", "No agents have started yet.")];
+    const start = Math.max(0, Math.min(this.selectedAgentIndex - Math.floor(height / 2), run.agents.length - height));
+    return run.agents.slice(start, start + height).map((agent, offset) => {
+      const index = start + offset;
+      const marker = index === this.selectedAgentIndex ? this.theme.fg("accent", "→") : " ";
+      const label = index === this.selectedAgentIndex ? this.theme.fg("accent", agent.label) : agent.label;
+      return truncateToWidth(`${marker} ${statusLabel(this.theme, agent.status)} ${label}  ${agent.phase ?? ""}  ${formatTokens(agent.tokens ?? 0)} tok · $${(agent.cost ?? 0).toFixed(3)}`, width);
+    });
+  }
+
+  private tabMarkdown(run: PersistedRunState): string {
+    if (this.tab === "result") return workflowResultMarkdown(run);
+    if (this.tab === "workflow") return `# Generated workflow\n\n\`\`\`javascript\n${run.script}\n\`\`\``;
+    const phaseLines = run.snapshot.phases.length
+      ? run.snapshot.phases.map((phase) => {
+          const agents = run.agents.filter((agent) => agent.phase === phase);
+          const done = agents.filter((agent) => agent.status === "done").length;
+          const icon = phase === run.snapshot.currentPhase && run.status === "running" ? "◆" : done === agents.length && agents.length ? "✓" : "○";
+          return `- ${icon} **${phase}** — ${done}/${agents.length} agents`;
+        }).join("\n")
+      : "_No phases declared._";
+    const logs = run.snapshot.logs.length ? `\n\n## Recent activity\n\n${run.snapshot.logs.slice(-20).map((line) => `- ${line}`).join("\n")}` : "";
+    return `# Progress\n\n${run.snapshot.description}\n\n${formatWorkflowRunSummary(run)}\n\n## Phases\n\n${phaseLines}${logs}${run.error ? `\n\n## Error\n\n${run.error}` : ""}`;
+  }
+
+  private handleRunsInput(data: string): void {
+    if (isCancel(data)) return this.done(null);
+    if (data === "n") return this.done("new");
+    if (data === "w") return this.done("saved");
+    if (data === "g") return this.done("setup");
+    if (data === "i") return this.done("settings");
+    if (data === "f") {
+      this.filter = FILTERS[(FILTERS.indexOf(this.filter) + 1) % FILTERS.length] ?? "all";
+      this.selectedRunId = this.runs()[0]?.runId;
+      return this.refresh();
+    }
+    const runs = this.runs();
+    if (!runs.length) return;
+    let index = Math.max(0, runs.findIndex((run) => run.runId === this.selectedRunId));
+    if (matchesKey(data, Key.up)) index = index === 0 ? runs.length - 1 : index - 1;
+    else if (matchesKey(data, Key.down)) index = index === runs.length - 1 ? 0 : index + 1;
+    else if (matchesKey(data, Key.enter)) {
+      const run = runs[index];
+      if (!run) return;
+      this.selectedRunId = run.runId;
+      this.tab = run.status === "completed" ? "result" : "progress";
+      this.screen = "detail";
+      this.scrollOffset = 0;
+      return this.refresh();
+    } else return;
+    this.selectedRunId = runs[index]?.runId;
+    this.refresh();
+  }
+
+  private handleDetailInput(data: string): void {
+    const run = this.currentRun();
+    if (!run) return;
+    if (isCancel(data)) {
+      this.screen = "runs";
+      this.scrollOffset = 0;
+      return this.refresh();
+    }
+    if (matchesKey(data, Key.tab) || matchesKey(data, Key.right) || matchesKey(data, Key.left)) {
+      const direction = matchesKey(data, Key.left) ? -1 : 1;
+      const index = (TABS.indexOf(this.tab) + direction + TABS.length) % TABS.length;
+      this.tab = TABS[index] ?? "result";
+      this.scrollOffset = 0;
+      return this.refresh();
+    }
+    if (this.tab === "agents" && (matchesKey(data, Key.up) || matchesKey(data, Key.down))) {
+      if (!run.agents.length) return;
+      this.selectedAgentIndex = matchesKey(data, Key.up)
+        ? (this.selectedAgentIndex - 1 + run.agents.length) % run.agents.length
+        : (this.selectedAgentIndex + 1) % run.agents.length;
+      return this.refresh();
+    }
+    if (this.tab === "agents" && matchesKey(data, Key.enter)) {
+      this.selectedAgent = run.agents[this.selectedAgentIndex];
+      if (this.selectedAgent) {
+        this.screen = "agent";
+        this.scrollOffset = 0;
+        return this.refresh();
+      }
+    }
+    if (this.handleScroll(data)) return;
+    if (data === "c") return void this.copy(workflowResultMarkdown(run), "Report copied.");
+    if (data === "m") {
+      const path = exportWorkflowReport(run, this.cwd, "markdown");
+      this.notify(`Saved Markdown report to ${path}`);
+      return;
+    }
+    if (data === "h") {
+      const path = exportWorkflowReport(run, this.cwd, "html");
+      this.notify(`Saved visual HTML report to ${path}`);
+      return;
+    }
+    if (data === "o") {
+      const path = exportWorkflowReport(run, this.cwd, "html");
+      openLocalFile(path, (error) => this.notify(error ? `Could not open HTML: ${error}` : `Opened ${path}`, error ? "error" : "info"));
+      return;
+    }
+    if (data === "s") {
+      const path = saveWorkflowScript(run, this.cwd);
+      this.notify(`Saved reusable workflow to ${path}`);
+      return;
+    }
+    if (data === "p") {
+      if (run.status === "running") this.notify(this.manager.pause(run.runId) ? `Paused ${run.workflowName}.` : "Could not pause this run.", "warning");
+      else if (run.status === "paused") void this.manager.resume(run.runId).then((ok) => this.notify(ok ? `Resumed ${run.workflowName}.` : "Could not resume this run.", ok ? "info" : "warning"));
+      return;
+    }
+    if (data === "x" && (run.status === "running" || run.status === "paused")) {
+      this.notify(this.manager.stop(run.runId) ? `Stopped ${run.workflowName}.` : "Could not stop this run.", "warning");
+    }
+  }
+
+  private handleAgentInput(data: string): void {
+    if (isCancel(data)) {
+      this.screen = "detail";
+      this.tab = "agents";
+      this.scrollOffset = 0;
+      return this.refresh();
+    }
+    if (this.handleScroll(data)) return;
+    if (data === "c" && this.selectedAgent) void this.copy(resultText(this.selectedAgent.result), "Agent result copied.");
+  }
+
+  private handleScroll(data: string): boolean {
+    let delta = 0;
+    if (matchesKey(data, Key.up)) delta = -1;
+    else if (matchesKey(data, Key.down)) delta = 1;
+    else if (matchesKey(data, Key.pageUp)) delta = -this.viewHeight;
+    else if (matchesKey(data, Key.pageDown)) delta = this.viewHeight;
+    else return false;
+    this.scrollOffset += delta;
+    this.clampScroll();
+    this.refresh();
+    return true;
+  }
+
+  private clampScroll(): void {
+    this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, Math.max(0, this.totalLines - this.viewHeight)));
+  }
+
+  private copy(text: string, message: string): void {
+    void copyToClipboard(text).then(() => this.notify(message)).catch((error) => this.notify(`Copy failed: ${String(error)}`, "error"));
+  }
+}
+
+function agentMarkdown(agent: WorkflowAgentSnapshot): string {
+  const prompt = agent.prompt?.trim() || "_Prompt was not captured for this older run._";
+  const activity = agent.activity?.length
+    ? agent.activity.map((item) => `- **${item.type === "tool_call" ? "Call" : "Result"}: ${item.name}${item.isError ? " (error)" : ""}${item.summary ? ` — ${item.summary.replace(/\n/g, " ")}` : ""}`).join("\n")
+    : "_No tool activity was captured._";
+  return `# Prompt\n\n${prompt}\n\n# Recent tool activity\n\n${activity}\n\n# Result\n\n${resultText(agent.result) || "_No result yet._"}${agent.error ? `\n\n# Error\n\n${agent.error}` : ""}`;
+}
+
+function workflowReportFile(run: PersistedRunState): string {
+  return `# ${run.workflowName}\n\n${formatWorkflowRunSummary(run)}\n\nRun ID: \`${run.runId}\`\n\n---\n\n${workflowResultMarkdown(run)}\n`;
+}
+
+function workflowReportHtml(run: PersistedRunState): string {
+  const agents = run.agents.map((agent) => `<details><summary>${escapeHtml(agent.label)} <span>${escapeHtml(agent.status)} · ${formatTokens(agent.tokens ?? 0)} tok · $${(agent.cost ?? 0).toFixed(4)}</span></summary><h3>Prompt</h3><pre>${escapeHtml(agent.prompt ?? "Prompt was not captured for this older run.")}</pre><h3>Result</h3><div class="agent-result">${simpleMarkdown(resultText(agent.result))}</div></details>`).join("\n");
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(run.workflowName)}</title><style>
+:root{color-scheme:dark;--bg:#0b1017;--panel:#121a24;--line:#263244;--text:#e7edf5;--muted:#91a0b4;--accent:#67e8f9;--ok:#86efac}*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at top right,#123044 0,transparent 35%),var(--bg);color:var(--text);font:15px/1.65 Inter,ui-sans-serif,system-ui,sans-serif}main{max-width:1120px;margin:auto;padding:48px 24px 80px}header{border-bottom:1px solid var(--line);padding-bottom:24px}h1{font-size:clamp(30px,5vw,54px);line-height:1.05;margin:8px 0}.eyebrow{color:var(--accent);text-transform:uppercase;letter-spacing:.16em;font-size:12px}.runid{color:var(--muted);font-family:ui-monospace,monospace}.metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin:26px 0}.metric{background:color-mix(in srgb,var(--panel) 88%,transparent);border:1px solid var(--line);border-radius:14px;padding:16px}.metric strong{display:block;font-size:22px}.metric span,summary span{color:var(--muted);font-size:13px}.layout{display:grid;grid-template-columns:minmax(0,1fr) 320px;gap:28px;margin-top:32px}.report,.agents{background:var(--panel);border:1px solid var(--line);border-radius:18px;padding:clamp(20px,4vw,38px)}.report h1,.report h2,.report h3{line-height:1.2;margin-top:1.5em}.report h1{font-size:30px}.report h2{font-size:23px;color:var(--accent)}code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}code{background:#081019;border:1px solid var(--line);border-radius:5px;padding:.1em .35em}pre{white-space:pre-wrap;overflow:auto;background:#081019;border:1px solid var(--line);border-radius:10px;padding:14px}.report table{width:100%;border-collapse:collapse}.report th,.report td{border:1px solid var(--line);padding:8px;text-align:left}.report a{color:var(--accent)}details{border-top:1px solid var(--line);padding:12px 0}summary{cursor:pointer;font-weight:650}.agent-result{font-size:13px}.agents h2{margin-top:0}@media(max-width:850px){.layout{grid-template-columns:1fr}}
+</style></head><body><main><header><div class="eyebrow">Pi workflow report</div><h1>${escapeHtml(run.workflowName)}</h1><div class="runid">${escapeHtml(run.runId)}</div><div class="metrics"><div class="metric"><strong>${escapeHtml(run.status)}</strong><span>Status</span></div><div class="metric"><strong>${run.snapshot.doneCount}/${run.snapshot.agentCount}</strong><span>Agents</span></div><div class="metric"><strong>${formatTokens(run.snapshot.tokens)}</strong><span>Tokens</span></div><div class="metric"><strong>$${run.snapshot.cost.toFixed(4)}</strong><span>Cost</span></div><div class="metric"><strong>${formatDuration(run.result?.durationMs ?? run.snapshot.durationMs ?? elapsedMs(run.startedAt, run.updatedAt))}</strong><span>Duration</span></div></div></header><div class="layout"><article class="report">${simpleMarkdown(workflowResultMarkdown(run))}</article><aside class="agents"><h2>Agent evidence</h2>${agents || "<p>No agents recorded.</p>"}<details><summary>Generated workflow</summary><pre>${escapeHtml(run.script)}</pre></details></aside></div></main></body></html>\n`;
+}
+
+function simpleMarkdown(markdown: string): string {
+  const lines = markdown.split(/\r?\n/);
+  const html: string[] = [];
+  let paragraph: string[] = [];
+  let list: "ul" | "ol" | undefined;
+  let code = false;
+  const flushParagraph = () => {
+    if (paragraph.length) html.push(`<p>${inlineMarkdown(paragraph.join(" "))}</p>`);
+    paragraph = [];
+  };
+  const closeList = () => {
+    if (list) html.push(`</${list}>`);
+    list = undefined;
+  };
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index] ?? "";
+    if (/^```/.test(line)) {
+      flushParagraph(); closeList();
+      html.push(code ? "</code></pre>" : "<pre><code>");
+      code = !code;
+      continue;
+    }
+    if (code) { html.push(`${escapeHtml(line)}\n`); continue; }
+    if (isTableRow(line) && isTableSeparator(lines[index + 1] ?? "")) {
+      flushParagraph(); closeList();
+      const headers = tableCells(line);
+      const rows: string[][] = [];
+      index += 2;
+      while (index < lines.length && isTableRow(lines[index] ?? "")) {
+        rows.push(tableCells(lines[index] ?? ""));
+        index += 1;
+      }
+      index -= 1;
+      html.push(`<table><thead><tr>${headers.map((cell) => `<th>${inlineMarkdown(cell)}</th>`).join("")}</tr></thead><tbody>${rows.map((row) => `<tr>${headers.map((_header, cellIndex) => `<td>${inlineMarkdown(row[cellIndex] ?? "")}</td>`).join("")}</tr>`).join("")}</tbody></table>`);
+      continue;
+    }
+    const heading = line.match(/^(#{1,6})\s+(.+)$/);
+    if (heading) { flushParagraph(); closeList(); const level = heading[1]?.length ?? 1; html.push(`<h${level}>${inlineMarkdown(heading[2] ?? "")}</h${level}>`); continue; }
+    if (/^\s*([-*_])\1{2,}\s*$/.test(line)) { flushParagraph(); closeList(); html.push("<hr>"); continue; }
+    const item = line.match(/^\s*([-*]|\d+\.)\s+(.+)$/);
+    if (item) { flushParagraph(); const nextList = item[1]?.endsWith(".") ? "ol" : "ul"; if (list !== nextList) { closeList(); list = nextList; html.push(`<${list}>`); } html.push(`<li>${inlineMarkdown(item[2] ?? "")}</li>`); continue; }
+    if (line.startsWith("> ")) { flushParagraph(); closeList(); html.push(`<blockquote>${inlineMarkdown(line.slice(2))}</blockquote>`); continue; }
+    if (!line.trim()) { flushParagraph(); closeList(); continue; }
+    paragraph.push(line.trim());
+  }
+  flushParagraph(); closeList(); if (code) html.push("</code></pre>");
+  return html.join("\n");
+}
+
+function inlineMarkdown(text: string): string {
+  return escapeHtml(text)
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" rel="noreferrer">$1</a>');
+}
+
+function isTableRow(line: string): boolean {
+  return line.includes("|") && tableCells(line).length > 1;
+}
+
+function isTableSeparator(line: string): boolean {
+  const cells = tableCells(line);
+  return cells.length > 1 && cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+function tableCells(line: string): string[] {
+  return line.trim().replace(/^\||\|$/g, "").split("|").map((cell) => cell.trim());
+}
+
+function openLocalFile(path: string, callback: (error?: string) => void): void {
+  const command = process.platform === "darwin" ? "open" : process.platform === "win32" ? "explorer" : "xdg-open";
+  const child = spawn(command, [path], { detached: true, stdio: "ignore" });
+  let settled = false;
+  child.once("error", (error) => {
+    settled = true;
+    callback(error.message);
+  });
+  child.once("spawn", () => {
+    child.unref();
+    if (!settled) callback();
+  });
+}
+
+function workflowExportsDir(cwd: string): string {
+  const key = createHash("sha256").update(cwd).digest("hex").slice(0, 16);
+  return join(homedir(), ".pi", "workflows", "projects", key, "exports");
+}
+
+function resultText(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  return typeof value === "string" ? value : JSON.stringify(value, null, 2);
+}
+
+function elapsedMs(start: string, end: string): number {
+  return Math.max(0, Date.parse(end) - Date.parse(start));
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(seconds / 60);
+  return minutes ? `${minutes}m ${seconds % 60}s` : `${seconds}s`;
+}
+
+function formatTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(2)}M`;
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(tokens >= 100_000 ? 0 : 1)}K`;
+  return String(tokens);
+}
+
+function statusLabel(theme: Theme, status: string): string {
+  if (status === "completed" || status === "done") return theme.fg("success", "✓");
+  if (status === "running") return theme.fg("accent", "◆");
+  if (status === "paused") return theme.fg("warning", "Ⅱ");
+  if (status === "queued") return theme.fg("muted", "○");
+  return theme.fg("error", "✗");
+}
+
+function frame(theme: Theme, lines: string[], width: number): string[] {
+  const innerWidth = Math.max(10, width - 2);
+  const border = (text: string) => theme.fg("borderMuted", text);
+  return [
+    border(`┌${"─".repeat(innerWidth)}┐`),
+    ...lines.map((line) => {
+      const truncated = truncateToWidth(line, innerWidth);
+      return `${border("│")}${truncated}${" ".repeat(Math.max(0, innerWidth - visibleWidth(truncated)))}${border("│")}`;
+    }),
+    border(`└${"─".repeat(innerWidth)}┘`),
+  ].map((line) => truncateToWidth(line, width));
+}
+
+function isCancel(data: string): boolean {
+  return matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c")) || data === "q";
+}
+
+function safeSlug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 64);
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[character] ?? character);
+}

--- a/extensions/workflow/runtime.ts
+++ b/extensions/workflow/runtime.ts
@@ -478,7 +478,7 @@ export function createWorkflowTool(options: { cwd?: string; manager: WorkflowMan
     promptSnippet: "Run a model-routed, resumable multi-agent JavaScript workflow.",
     promptGuidelines: [
       "Use workflow only when the user explicitly asks for a workflow, fan-out, or multi-agent orchestration.",
-      "Pass raw JavaScript in script, beginning with export const meta = { name, description, phases }.",
+      "Pass raw JavaScript in script, beginning with export const meta = { name, description, phases: [{ title: 'Inspect' }] }.",
       "Available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), retry(thunk, { attempts }), gate(thunk, validator, { attempts }), checkpoint(question), budget, args, and cwd.",
       "parallel() receives functions, not promises: await parallel(items.map(item => () => agent(...))).",
       "Every agent needs a unique short label and a semantic opts.tier. End with one synthesizer agent and return a compact JSON-serializable result.",
@@ -564,22 +564,35 @@ export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body:
   if (meta.phases !== undefined) {
     if (!Array.isArray(meta.phases)) throw new Error("Workflow meta.phases must be an array.");
     phases = meta.phases.map((phase) => {
-      if (!phase || typeof phase !== "object" || typeof (phase as any).title !== "string") {
+      const title = typeof phase === "string" ? phase : (phase as any)?.title;
+      if (typeof title !== "string" || !title.trim()) {
         throw new Error("Each workflow phase needs a title.");
       }
-      return { title: (phase as any).title };
+      return { title: title.trim() };
     });
   }
+  const remaining = program.body.slice(1);
+  const defaultRun = remaining.length === 1 ? remaining[0] : undefined;
+  const runDeclaration = defaultRun?.type === "ExportDefaultDeclaration" ? defaultRun.declaration : undefined;
+  const runBody =
+    (runDeclaration?.type === "FunctionDeclaration" || runDeclaration?.type === "FunctionExpression") &&
+    runDeclaration.body?.type === "BlockStatement"
+      ? runDeclaration.body
+      : runDeclaration?.type === "ArrowFunctionExpression" && runDeclaration.body?.type === "BlockStatement"
+        ? runDeclaration.body
+        : undefined;
   return {
     meta: { name: meta.name.trim(), description: meta.description.trim(), phases },
-    body: `${script.slice(0, first.start)}${script.slice(first.end)}`,
+    body: runBody
+      ? script.slice(runBody.start + 1, runBody.end - 1)
+      : `${script.slice(0, first.start)}${script.slice(first.end)}`,
   };
 }
 
 export function buildForcedWorkflowPrompt(prompt: string, directive?: string): string {
   return [
     "The user explicitly requested a dynamic workflow. You must call the workflow tool exactly once.",
-    "Design the JavaScript orchestration, then pass it as the tool's script argument. Do not perform the task with ordinary tools in this parent turn.",
+    "Design the JavaScript orchestration, then pass it as the tool's script argument. Metadata phases must use [{ title: 'Phase name' }]. Write orchestration as top-level statements or an export default async function run(). Do not perform the task with ordinary tools in this parent turn.",
     directive ?? "",
     "User request:",
     prompt,

--- a/extensions/workflow/runtime.ts
+++ b/extensions/workflow/runtime.ts
@@ -60,12 +60,21 @@ export interface WorkflowAgentSnapshot {
   label: string;
   status: "queued" | "running" | "done" | "error" | "skipped";
   phase?: string;
+  prompt?: string;
   model?: string;
   result?: unknown;
   error?: string;
   cached?: boolean;
   tokens?: number;
   cost?: number;
+  activity?: WorkflowAgentActivity[];
+}
+
+export interface WorkflowAgentActivity {
+  type: "tool_call" | "tool_result";
+  name: string;
+  summary?: string;
+  isError?: boolean;
 }
 
 export interface WorkflowSnapshot {
@@ -92,6 +101,7 @@ interface JournalEntry {
   model?: string;
   tokens?: number;
   cost?: number;
+  activity?: WorkflowAgentActivity[];
 }
 
 export type RunStatus = "running" | "paused" | "completed" | "failed" | "aborted";
@@ -162,6 +172,7 @@ interface AgentRunResult {
   model: string;
   tokens: number;
   cost: number;
+  activity?: WorkflowAgentActivity[];
 }
 
 interface ExecuteOptions extends ExecOptions {
@@ -617,14 +628,27 @@ export function loadModelTierConfig(path = modelTierPath()): ModelTierConfig {
 
 export function deliverText(run: ManagedRun): string {
   const result = run.result;
-  const summary = result?.result === undefined ? "No result." : JSON.stringify(result.result, null, 2);
+  const summary = workflowResultText(result?.result);
   return [
     `✓ Background workflow "${run.workflowName}" finished (${result?.agentCount ?? run.snapshot.agentCount} agents, ${run.snapshot.tokens} tokens, $${run.snapshot.cost.toFixed(4)}).`,
     "",
-    summary.length > 2000 ? `${summary.slice(0, 2000)}\n…` : summary,
+    summary,
     "",
     `Run ID: ${run.runId}`,
+    `Inspect details, agent evidence, and exports with /workflow status ${run.runId}`,
   ].join("\n");
+}
+
+export function workflowResultText(value: unknown): string {
+  if (value === undefined || value === null) return "No result.";
+  if (typeof value === "string") return value;
+  if (typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    for (const key of ["report", "markdown", "content", "text", "summary"]) {
+      if (typeof record[key] === "string" && record[key].trim()) return record[key] as string;
+    }
+  }
+  return JSON.stringify(value, null, 2);
 }
 
 export function renderPanel(manager: WorkflowManager, theme: Theme, _width?: number): string[] {
@@ -669,7 +693,7 @@ async function executeWorkflow(script: string, args: unknown, options: ExecuteOp
     const phaseName = callOptions.phase ?? currentPhase;
     const fingerprint = hashCall(prompt, callOptions);
     const prior = cached.get(index);
-    const row: WorkflowAgentSnapshot = { id: index + 1, label, status: "queued", phase: phaseName };
+    const row: WorkflowAgentSnapshot = { id: index + 1, label, status: "queued", phase: phaseName, prompt };
     snapshot.agents.push(row);
     update();
 
@@ -680,6 +704,7 @@ async function executeWorkflow(script: string, args: unknown, options: ExecuteOp
       row.model = prior.model;
       row.tokens = prior.tokens;
       row.cost = prior.cost;
+      row.activity = prior.activity;
       journal.push(prior);
       options.onJournal?.([...journal]);
       update();
@@ -703,6 +728,7 @@ async function executeWorkflow(script: string, args: unknown, options: ExecuteOp
           row.model = result.model;
           row.tokens = result.tokens;
           row.cost = result.cost;
+          row.activity = result.activity;
           const entry: JournalEntry = {
             callIndex: index,
             hash: fingerprint,
@@ -710,6 +736,7 @@ async function executeWorkflow(script: string, args: unknown, options: ExecuteOp
             model: result.model,
             tokens: result.tokens,
             cost: result.cost,
+            activity: result.activity,
           };
           journal.push(entry);
           options.onJournal?.([...journal]);
@@ -855,7 +882,13 @@ async function runAgent(prompt: string, options: AgentCallOptions, run: ExecuteO
     const output = lastAssistantText(session.messages);
     if (!output) throw new Error("Subagent returned no text result.");
     const stats = session.getSessionStats();
-    return { output, model: spec, tokens: stats.tokens.total, cost: stats.cost };
+    return {
+      output,
+      model: spec,
+      tokens: stats.tokens.total,
+      cost: stats.cost,
+      activity: extractAgentActivity(session.messages),
+    };
   } finally {
     run.signal.removeEventListener("abort", abort);
     session.dispose();
@@ -894,6 +927,39 @@ function lastAssistantText(messages: readonly any[]): string {
     }
   }
   return "";
+}
+
+function extractAgentActivity(messages: readonly any[]): WorkflowAgentActivity[] {
+  const activity: WorkflowAgentActivity[] = [];
+  for (const message of messages) {
+    if (message?.role === "assistant" && Array.isArray(message.content)) {
+      for (const part of message.content) {
+        if (part?.type !== "toolCall" || typeof part.name !== "string") continue;
+        const args = part.arguments && Object.keys(part.arguments).length ? JSON.stringify(part.arguments) : undefined;
+        activity.push({ type: "tool_call", name: part.name, summary: truncateActivity(args) });
+      }
+      continue;
+    }
+    if (message?.role !== "toolResult" || typeof message.toolName !== "string") continue;
+    const text = typeof message.content === "string"
+      ? message.content
+      : Array.isArray(message.content)
+        ? message.content.filter((part: any) => part?.type === "text").map((part: any) => part.text).join("\n")
+        : undefined;
+    activity.push({
+      type: "tool_result",
+      name: message.toolName,
+      summary: truncateActivity(text),
+      isError: message.isError,
+    });
+  }
+  return activity.slice(-20);
+}
+
+function truncateActivity(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const text = String(value).trim();
+  return text.length > 500 ? `${text.slice(0, 500)}…` : text || undefined;
 }
 
 function literalValue(node: any): unknown {

--- a/extensions/workflow/runtime.ts
+++ b/extensions/workflow/runtime.ts
@@ -1,0 +1,1005 @@
+import { createHash, randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+import type { Model, ThinkingLevel } from "@earendil-works/pi-ai";
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  defineTool,
+  getAgentDir,
+  ModelRuntime,
+  SessionManager,
+  SettingsManager,
+  type ExtensionContext,
+  type ModelRegistry,
+  type Theme,
+} from "@earendil-works/pi-coding-agent";
+import { parse } from "acorn";
+import { Type } from "typebox";
+
+const MAX_CONCURRENCY = 16;
+const MAX_AGENTS = 1000;
+export interface ModelTierConfig {
+  tiers: Record<string, string>;
+}
+
+export interface WorkflowMetaPhase {
+  title: string;
+}
+
+export interface WorkflowMeta {
+  name: string;
+  description: string;
+  phases?: WorkflowMetaPhase[];
+}
+
+export interface WorkflowToolInput {
+  script: string;
+  args?: unknown;
+  background?: boolean;
+  maxAgents?: number;
+  concurrency?: number;
+  agentRetries?: number;
+  tokenBudget?: number;
+  resumeFromRunId?: string;
+}
+
+export interface WorkflowAgentSnapshot {
+  id: number;
+  label: string;
+  status: "queued" | "running" | "done" | "error" | "skipped";
+  phase?: string;
+  model?: string;
+  result?: unknown;
+  error?: string;
+  cached?: boolean;
+  tokens?: number;
+  cost?: number;
+}
+
+export interface WorkflowSnapshot {
+  name: string;
+  description: string;
+  phases: string[];
+  currentPhase?: string;
+  agents: WorkflowAgentSnapshot[];
+  logs: string[];
+  result?: unknown;
+  durationMs?: number;
+  agentCount: number;
+  runningCount: number;
+  doneCount: number;
+  errorCount: number;
+  tokens: number;
+  cost: number;
+}
+
+interface JournalEntry {
+  callIndex: number;
+  hash: string;
+  result: unknown;
+  model?: string;
+  tokens?: number;
+  cost?: number;
+}
+
+export type RunStatus = "running" | "paused" | "completed" | "failed" | "aborted";
+
+export interface WorkflowRunResult {
+  meta: WorkflowMeta;
+  result: unknown;
+  agentCount: number;
+  durationMs: number;
+  tokens: number;
+  cost: number;
+  journal: JournalEntry[];
+}
+
+export interface PersistedRunState {
+  runId: string;
+  workflowName: string;
+  status: RunStatus;
+  snapshot: WorkflowSnapshot;
+  agents: WorkflowAgentSnapshot[];
+  script: string;
+  args?: unknown;
+  journal: JournalEntry[];
+  result?: WorkflowRunResult;
+  error?: string;
+  startedAt: string;
+  updatedAt: string;
+  sessionId?: string;
+  ownerPid?: number;
+}
+
+export interface ManagedRun extends PersistedRunState {
+  controller: AbortController;
+  background: boolean;
+}
+
+interface WorkflowManagerOptions {
+  cwd?: string;
+  runsDir?: string;
+  loadSavedWorkflow?: (name: string) => string | undefined;
+  defaultAgentRetries?: number;
+  agent?: (prompt: string, options: AgentCallOptions) => Promise<AgentRunResult>;
+}
+
+interface ExecOptions {
+  maxAgents?: number;
+  concurrency?: number;
+  tokenBudget?: number;
+  agentRetries?: number;
+  externalSignal?: AbortSignal;
+  confirm?: (question: string, options?: unknown) => Promise<unknown>;
+  onProgress?: (snapshot: WorkflowSnapshot) => void;
+  resumeJournal?: JournalEntry[];
+  onJournal?: (journal: JournalEntry[]) => void;
+}
+
+interface AgentCallOptions {
+  label?: string;
+  phase?: string;
+  tier?: string;
+  model?: string;
+  tools?: string[];
+  disallowedTools?: string[];
+}
+
+interface AgentRunResult {
+  output: string;
+  model: string;
+  tokens: number;
+  cost: number;
+}
+
+interface ExecuteOptions extends ExecOptions {
+  cwd: string;
+  runId: string;
+  signal: AbortSignal;
+  modelRegistry?: ModelRegistry;
+  modelRuntime?: ModelRuntime;
+  mainModel?: string;
+  resumeJournal?: JournalEntry[];
+  loadSavedWorkflow?: (name: string) => string | undefined;
+  agentRunner?: (prompt: string, options: AgentCallOptions) => Promise<AgentRunResult>;
+}
+
+type ProviderRegistration = Parameters<ModelRuntime["registerProvider"]>[1];
+
+const workflowToolSchema = Type.Object({
+  script: Type.String(),
+  args: Type.Optional(Type.Any()),
+  background: Type.Optional(Type.Boolean()),
+  maxAgents: Type.Optional(Type.Number()),
+  concurrency: Type.Optional(Type.Number()),
+  agentRetries: Type.Optional(Type.Number()),
+  tokenBudget: Type.Optional(Type.Number()),
+  resumeFromRunId: Type.Optional(Type.String()),
+});
+
+export class WorkflowManager extends EventEmitter {
+  private readonly cwd: string;
+  private readonly runs = new Map<string, ManagedRun>();
+  private readonly runsDir: string;
+  private readonly loadSavedWorkflow?: (name: string) => string | undefined;
+  private readonly defaultAgentRetries: number;
+  private readonly agentRunner?: (prompt: string, options: AgentCallOptions) => Promise<AgentRunResult>;
+  private modelRegistry?: ModelRegistry;
+  private modelRuntimePromise?: Promise<ModelRuntime>;
+  private readonly registeredProviders = new Map<string, ProviderRegistration>();
+  private mainModel?: string;
+  private sessionId?: string;
+
+  constructor(options: WorkflowManagerOptions = {}) {
+    super();
+    this.cwd = options.cwd ?? process.cwd();
+    this.loadSavedWorkflow = options.loadSavedWorkflow;
+    this.defaultAgentRetries = options.defaultAgentRetries ?? 0;
+    this.runsDir = options.runsDir ?? workflowRunsDir(this.cwd);
+    this.agentRunner = options.agent;
+    mkdirSync(this.runsDir, { recursive: true });
+    this.recoverInterruptedRuns();
+  }
+
+  setMainModel(spec: string | undefined): void {
+    this.mainModel = spec;
+  }
+
+  setModelRegistry(registry: ModelRegistry): void {
+    this.modelRegistry = registry;
+    this.registeredProviders.clear();
+    for (const providerId of registry.getRegisteredProviderIds()) {
+      const config = registry.getRegisteredProviderConfig(providerId);
+      if (config) this.registeredProviders.set(providerId, config);
+    }
+    if (this.modelRuntimePromise) {
+      void this.modelRuntimePromise.then((runtime) => this.applyRegisteredProviders(runtime));
+    }
+  }
+
+  setSessionId(sessionId: string | undefined): void {
+    this.sessionId = sessionId;
+  }
+
+  startInBackground(
+    script: string,
+    args?: unknown,
+    options: ExecOptions = {},
+  ): { runId: string; promise: Promise<WorkflowRunResult> } {
+    const run = this.createRun(script, args, true);
+    const promise = this.execute(run, options);
+    return { runId: run.runId, promise };
+  }
+
+  runSync(script: string, args?: unknown, options: ExecOptions = {}): Promise<WorkflowRunResult> {
+    return this.execute(this.createRun(script, args, false), options);
+  }
+
+  pause(runId: string): boolean {
+    const run = this.runs.get(runId);
+    if (!run || run.status !== "running") return false;
+    run.status = "paused";
+    run.updatedAt = new Date().toISOString();
+    this.persist(run);
+    run.controller.abort(new Error("Workflow paused"));
+    this.emit("paused", { runId });
+    return true;
+  }
+
+  stop(runId: string): boolean {
+    const run = this.runs.get(runId);
+    if (!run || (run.status !== "running" && run.status !== "paused")) return false;
+    run.status = "aborted";
+    run.updatedAt = new Date().toISOString();
+    this.persist(run);
+    run.controller.abort(new Error("Workflow stopped"));
+    this.emit("stopped", { runId });
+    return true;
+  }
+
+  async resume(runId: string): Promise<boolean> {
+    const persisted = this.readRun(runId);
+    if (!persisted || persisted.status !== "paused") return false;
+    const run: ManagedRun = {
+      ...persisted,
+      status: "running",
+      controller: new AbortController(),
+      background: true,
+      updatedAt: new Date().toISOString(),
+      ownerPid: process.pid,
+    };
+    this.runs.set(runId, run);
+    this.persist(run);
+    void this.execute(run, { resumeJournal: persisted.journal }).catch(() => {});
+    return true;
+  }
+
+  getRun(runId: string): ManagedRun | undefined {
+    return this.runs.get(runId);
+  }
+
+  getSnapshot(runId: string): WorkflowSnapshot | null {
+    return this.runs.get(runId)?.snapshot ?? this.readRun(runId)?.snapshot ?? null;
+  }
+
+  listRuns(): PersistedRunState[] {
+    const runs = this.readAllRuns();
+    const filtered = this.sessionId ? runs.filter((run) => run.sessionId === this.sessionId) : runs;
+    return filtered.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  listAllRuns(): PersistedRunState[] {
+    return this.readAllRuns().sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  deleteRun(runId: string): boolean {
+    if (!isSafeRunId(runId)) return false;
+    const live = this.runs.get(runId);
+    if (live?.status === "running") return false;
+    this.runs.delete(runId);
+    const path = this.runPath(runId);
+    if (!existsSync(path)) return false;
+    rmSync(path);
+    return true;
+  }
+
+  private createRun(script: string, args: unknown, background: boolean): ManagedRun {
+    const { meta } = parseWorkflowScript(script);
+    const slug = meta.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 32);
+    const runId = `${slug || "workflow"}-${Date.now().toString(36)}-${randomUUID().slice(0, 6)}`;
+    const now = new Date().toISOString();
+    const run: ManagedRun = {
+      runId,
+      workflowName: meta.name,
+      status: "running",
+      snapshot: createSnapshot(meta),
+      agents: [],
+      script,
+      args,
+      journal: [],
+      startedAt: now,
+      updatedAt: now,
+      sessionId: this.sessionId,
+      ownerPid: process.pid,
+      controller: new AbortController(),
+      background,
+    };
+    this.runs.set(runId, run);
+    this.persist(run);
+    return run;
+  }
+
+  private async execute(run: ManagedRun, options: ExecOptions): Promise<WorkflowRunResult> {
+    const externalAbort = () => run.controller.abort(options.externalSignal?.reason);
+    options.externalSignal?.addEventListener("abort", externalAbort, { once: true });
+    try {
+      const result = await executeWorkflow(run.script, run.args, {
+        ...options,
+        cwd: this.cwd,
+        runId: run.runId,
+        signal: run.controller.signal,
+        modelRegistry: this.modelRegistry,
+        modelRuntime: this.agentRunner ? undefined : await this.getModelRuntime(),
+        mainModel: this.mainModel,
+        loadSavedWorkflow: this.loadSavedWorkflow,
+        agentRunner: this.agentRunner,
+        agentRetries: options.agentRetries ?? this.defaultAgentRetries,
+        resumeJournal: options.resumeJournal,
+        onJournal: (journal) => {
+          run.journal = journal;
+          run.updatedAt = new Date().toISOString();
+          this.persist(run);
+        },
+        onProgress: (snapshot) => {
+          run.snapshot = snapshot;
+          run.agents = snapshot.agents;
+          run.updatedAt = new Date().toISOString();
+          this.persist(run);
+          options.onProgress?.(snapshot);
+          this.emit("progress", { runId: run.runId, snapshot });
+        },
+      });
+      run.status = "completed";
+      run.result = result;
+      run.journal = result.journal;
+      run.snapshot.result = result.result;
+      run.snapshot.durationMs = result.durationMs;
+      run.updatedAt = new Date().toISOString();
+      this.persist(run);
+      this.emit("complete", { runId: run.runId, result });
+      return result;
+    } catch (error) {
+      if (run.status !== "paused" && run.status !== "aborted") {
+        run.status = "failed";
+        run.error = error instanceof Error ? error.message : String(error);
+        run.updatedAt = new Date().toISOString();
+        this.persist(run);
+        this.emit("error", { runId: run.runId, error });
+      }
+      throw error;
+    } finally {
+      options.externalSignal?.removeEventListener("abort", externalAbort);
+    }
+  }
+
+  private getModelRuntime(): Promise<ModelRuntime> {
+    this.modelRuntimePromise ??= ModelRuntime.create().then((runtime) => {
+      this.applyRegisteredProviders(runtime);
+      return runtime;
+    });
+    return this.modelRuntimePromise;
+  }
+
+  private applyRegisteredProviders(runtime: ModelRuntime): void {
+    for (const [providerId, config] of this.registeredProviders) runtime.registerProvider(providerId, config);
+  }
+
+  private persist(run: ManagedRun): void {
+    const persisted: PersistedRunState = {
+      runId: run.runId,
+      workflowName: run.workflowName,
+      status: run.status,
+      snapshot: run.snapshot,
+      agents: run.snapshot.agents,
+      script: run.script,
+      args: run.args,
+      journal: run.journal,
+      result: run.result,
+      error: run.error,
+      startedAt: run.startedAt,
+      updatedAt: run.updatedAt,
+      sessionId: run.sessionId,
+      ownerPid: run.ownerPid,
+    };
+    const path = this.runPath(run.runId);
+    const temp = `${path}.${process.pid}.tmp`;
+    writeFileSync(temp, `${JSON.stringify(persisted, null, 2)}\n`, "utf8");
+    renameSync(temp, path);
+  }
+
+  private recoverInterruptedRuns(): void {
+    for (const run of this.readAllRuns()) {
+      if (run.status !== "running") continue;
+      if (run.ownerPid && isProcessAlive(run.ownerPid)) continue;
+      run.status = "paused";
+      run.updatedAt = new Date().toISOString();
+      const path = this.runPath(run.runId);
+      writeFileSync(path, `${JSON.stringify(run, null, 2)}\n`, "utf8");
+    }
+  }
+
+  private readAllRuns(): PersistedRunState[] {
+    if (!existsSync(this.runsDir)) return [];
+    const runs: PersistedRunState[] = [];
+    for (const entry of readdirSync(this.runsDir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+      try {
+        const run = JSON.parse(readFileSync(join(this.runsDir, entry.name), "utf8"));
+        if (run && typeof run.runId === "string" && isSafeRunId(run.runId)) runs.push(run as PersistedRunState);
+      } catch {
+        // A corrupt run does not hide valid history.
+      }
+    }
+    return runs;
+  }
+
+  private readRun(runId: string): PersistedRunState | undefined {
+    if (!isSafeRunId(runId)) return undefined;
+    try {
+      return JSON.parse(readFileSync(this.runPath(runId), "utf8")) as PersistedRunState;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private runPath(runId: string): string {
+    return join(this.runsDir, `${runId}.json`);
+  }
+}
+
+export function createWorkflowTool(options: { cwd?: string; manager: WorkflowManager }) {
+  const manager = options.manager;
+  return defineTool({
+    name: "workflow",
+    label: "Workflow",
+    description: "Execute an approved JavaScript workflow that coordinates multiple Pi subagents.",
+    promptSnippet: "Run a model-routed, resumable multi-agent JavaScript workflow.",
+    promptGuidelines: [
+      "Use workflow only when the user explicitly asks for a workflow, fan-out, or multi-agent orchestration.",
+      "Pass raw JavaScript in script, beginning with export const meta = { name, description, phases }.",
+      "Available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), retry(thunk, { attempts }), gate(thunk, validator, { attempts }), checkpoint(question), budget, args, and cwd.",
+      "parallel() receives functions, not promises: await parallel(items.map(item => () => agent(...))).",
+      "Every agent needs a unique short label and a semantic opts.tier. End with one synthesizer agent and return a compact JSON-serializable result.",
+      "Do not use imports, require, process, filesystem APIs, Date.now, Math.random, or new Date in workflow JavaScript.",
+      "Runs are background by default. The completed result returns to the conversation automatically.",
+    ],
+    parameters: workflowToolSchema,
+    async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+      if (params.resumeFromRunId) {
+        const resumed = await manager.resume(params.resumeFromRunId);
+        if (!resumed) throw new Error(`Workflow ${params.resumeFromRunId} is not resumable.`);
+        return {
+          content: [{ type: "text" as const, text: `Workflow ${params.resumeFromRunId} resumed in the background.` }],
+          details: { runId: params.resumeFromRunId, background: true },
+        };
+      }
+      if (params.background ?? true) {
+        const { runId, promise } = manager.startInBackground(params.script, params.args, {
+          maxAgents: params.maxAgents,
+          concurrency: params.concurrency,
+          tokenBudget: params.tokenBudget,
+          agentRetries: params.agentRetries,
+        });
+        void promise.catch(() => {});
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Workflow started in the background. Run ID: ${runId}. Its result will return to this conversation.`,
+            },
+          ],
+          details: { runId, background: true },
+        };
+      }
+      const result = await manager.runSync(params.script, params.args, {
+        maxAgents: params.maxAgents,
+        concurrency: params.concurrency,
+        tokenBudget: params.tokenBudget,
+        agentRetries: params.agentRetries,
+        externalSignal: signal,
+        onProgress: (snapshot) =>
+          onUpdate?.({
+            content: [{ type: "text" as const, text: progressText(snapshot) }],
+            details: snapshot,
+          }),
+      });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Workflow ${result.meta.name} completed with ${result.agentCount} agents.\n\n${JSON.stringify(result.result, null, 2)}`,
+          },
+        ],
+        details: result,
+      };
+    },
+  });
+}
+
+export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body: string } {
+  if (typeof script !== "string" || !script.trim()) throw new Error("Workflow script is empty.");
+  const program = parse(script, {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    allowReturnOutsideFunction: true,
+  }) as any;
+  const first = program.body[0];
+  if (first?.type !== "ExportNamedDeclaration" || first.declaration?.type !== "VariableDeclaration") {
+    throw new Error("Workflow script must begin with `export const meta = { ... }`.");
+  }
+  const declaration = first.declaration.declarations?.[0];
+  if (declaration?.id?.name !== "meta" || !declaration.init) {
+    throw new Error("Workflow script must begin with `export const meta = { ... }`.");
+  }
+  const raw = literalValue(declaration.init);
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("Workflow meta must be an object.");
+  const meta = raw as Record<string, unknown>;
+  if (typeof meta.name !== "string" || !meta.name.trim()) throw new Error("Workflow meta.name is required.");
+  if (typeof meta.description !== "string" || !meta.description.trim()) {
+    throw new Error("Workflow meta.description is required.");
+  }
+  let phases: WorkflowMetaPhase[] | undefined;
+  if (meta.phases !== undefined) {
+    if (!Array.isArray(meta.phases)) throw new Error("Workflow meta.phases must be an array.");
+    phases = meta.phases.map((phase) => {
+      if (!phase || typeof phase !== "object" || typeof (phase as any).title !== "string") {
+        throw new Error("Each workflow phase needs a title.");
+      }
+      return { title: (phase as any).title };
+    });
+  }
+  return {
+    meta: { name: meta.name.trim(), description: meta.description.trim(), phases },
+    body: `${script.slice(0, first.start)}${script.slice(first.end)}`,
+  };
+}
+
+export function buildForcedWorkflowPrompt(prompt: string, directive?: string): string {
+  return [
+    "The user explicitly requested a dynamic workflow. You must call the workflow tool exactly once.",
+    "Design the JavaScript orchestration, then pass it as the tool's script argument. Do not perform the task with ordinary tools in this parent turn.",
+    directive ?? "",
+    "User request:",
+    prompt,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+export function saveModelTierConfig(config: ModelTierConfig, path = modelTierPath()): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+}
+
+export function loadModelTierConfig(path = modelTierPath()): ModelTierConfig {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    return parsed && typeof parsed.tiers === "object" ? parsed : { tiers: {} };
+  } catch {
+    return { tiers: {} };
+  }
+}
+
+export function deliverText(run: ManagedRun): string {
+  const result = run.result;
+  const summary = result?.result === undefined ? "No result." : JSON.stringify(result.result, null, 2);
+  return [
+    `✓ Background workflow "${run.workflowName}" finished (${result?.agentCount ?? run.snapshot.agentCount} agents, ${run.snapshot.tokens} tokens, $${run.snapshot.cost.toFixed(4)}).`,
+    "",
+    summary.length > 2000 ? `${summary.slice(0, 2000)}\n…` : summary,
+    "",
+    `Run ID: ${run.runId}`,
+  ].join("\n");
+}
+
+export function renderPanel(manager: WorkflowManager, theme: Theme, _width?: number): string[] {
+  const active = manager.listRuns().filter((run) => run.status === "running" || run.status === "paused");
+  if (!active.length) return [];
+  return [
+    theme.bold(`Workflows running (${active.length}):`),
+    ...active.map((run) => {
+      const snap = manager.getSnapshot(run.runId) ?? run.snapshot;
+      const icon = run.status === "paused" ? "⏸" : "◆";
+      const phase = snap.currentPhase ? ` · ${snap.currentPhase}` : "";
+      return `  ${icon} ${run.workflowName}  ${snap.doneCount}/${snap.agentCount} agents${phase}`;
+    }),
+    theme.fg("dim", "  /workflow active — inspect runs"),
+  ];
+}
+
+async function executeWorkflow(script: string, args: unknown, options: ExecuteOptions): Promise<WorkflowRunResult> {
+  const started = Date.now();
+  const { meta, body } = parseWorkflowScript(script);
+  const snapshot = createSnapshot(meta);
+  const maxAgents = clampInteger(options.maxAgents, 1, MAX_AGENTS, MAX_AGENTS);
+  const concurrency = clampInteger(options.concurrency, 1, MAX_CONCURRENCY, 4);
+  const retries = clampInteger(options.agentRetries, 0, 3, 0);
+  const semaphore = new Semaphore(concurrency);
+  const journal: JournalEntry[] = [];
+  const cached = new Map((options.resumeJournal ?? []).map((entry) => [entry.callIndex, entry]));
+  let cachePrefixValid = true;
+  let callIndex = 0;
+  let currentPhase = meta.phases?.[0]?.title;
+
+  const update = () => {
+    recompute(snapshot);
+    options.onProgress?.(structuredClone(snapshot));
+  };
+
+  const agent = async (prompt: string, callOptions: AgentCallOptions = {}): Promise<unknown> => {
+    if (options.signal.aborted) throw abortError(options.signal.reason);
+    const index = callIndex++;
+    if (index >= maxAgents) throw new Error(`Workflow exceeded its ${maxAgents}-agent cap.`);
+    const label = callOptions.label?.trim() || `agent ${index + 1}`;
+    const phaseName = callOptions.phase ?? currentPhase;
+    const fingerprint = hashCall(prompt, callOptions);
+    const prior = cached.get(index);
+    const row: WorkflowAgentSnapshot = { id: index + 1, label, status: "queued", phase: phaseName };
+    snapshot.agents.push(row);
+    update();
+
+    if (cachePrefixValid && prior?.callIndex === index && prior.hash === fingerprint) {
+      row.status = "done";
+      row.cached = true;
+      row.result = prior.result;
+      row.model = prior.model;
+      row.tokens = prior.tokens;
+      row.cost = prior.cost;
+      journal.push(prior);
+      options.onJournal?.([...journal]);
+      update();
+      return prior.result;
+    }
+    cachePrefixValid = false;
+
+    return semaphore.run(async () => {
+      if (options.signal.aborted) throw abortError(options.signal.reason);
+      row.status = "running";
+      update();
+      let lastError: unknown;
+      for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+          const result = options.agentRunner
+            ? await options.agentRunner(prompt, callOptions)
+            : await runAgent(prompt, callOptions, options);
+          if (options.signal.aborted) throw abortError(options.signal.reason);
+          row.status = "done";
+          row.result = result.output;
+          row.model = result.model;
+          row.tokens = result.tokens;
+          row.cost = result.cost;
+          const entry: JournalEntry = {
+            callIndex: index,
+            hash: fingerprint,
+            result: result.output,
+            model: result.model,
+            tokens: result.tokens,
+            cost: result.cost,
+          };
+          journal.push(entry);
+          options.onJournal?.([...journal]);
+          update();
+          if (options.tokenBudget && snapshot.tokens > options.tokenBudget) {
+            throw new Error(`Workflow exceeded its ${options.tokenBudget}-token budget.`);
+          }
+          return result.output;
+        } catch (error) {
+          if (options.signal.aborted) throw abortError(options.signal.reason);
+          lastError = error;
+        }
+      }
+      row.status = "error";
+      row.error = lastError instanceof Error ? lastError.message : String(lastError);
+      update();
+      return null;
+    });
+  };
+
+  const parallel = async (thunks: Array<() => Promise<unknown>>): Promise<unknown[]> => Promise.all(thunks.map((fn) => fn()));
+  const pipeline = async (items: unknown[], ...stages: Array<(value: unknown, original: unknown, index: number) => unknown>) =>
+    Promise.all(
+      items.map(async (original, index) => {
+        let value = original;
+        for (const stage of stages) value = await stage(value, original, index);
+        return value;
+      }),
+    );
+  const phase = (title: string) => {
+    currentPhase = title;
+    snapshot.currentPhase = title;
+    snapshot.logs.push(`phase: ${title}`);
+    update();
+  };
+  const log = (message: unknown) => {
+    snapshot.logs.push(String(message));
+    update();
+  };
+  const retry = async (thunk: () => Promise<unknown>, retryOptions: { attempts?: number } = {}) => {
+    const attempts = clampInteger(retryOptions.attempts, 1, 10, 2);
+    let lastError: unknown;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      try {
+        return await thunk();
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError;
+  };
+  const gate = async (
+    thunk: () => Promise<unknown>,
+    validator: (value: unknown) => boolean | Promise<boolean>,
+    gateOptions: { attempts?: number } = {},
+  ) => retry(async () => {
+    const value = await thunk();
+    if (!(await validator(value))) throw new Error("Workflow gate rejected the result.");
+    return value;
+  }, gateOptions);
+  const checkpoint = async (question: string, checkpointOptions?: unknown) => {
+    if (!options.confirm) throw new Error("This workflow checkpoint requires interactive mode.");
+    return options.confirm(question, checkpointOptions);
+  };
+  const budget = {
+    total: options.tokenBudget ?? null,
+    used: () => snapshot.tokens,
+    remaining: () => (options.tokenBudget ? Math.max(0, options.tokenBudget - snapshot.tokens) : Number.POSITIVE_INFINITY),
+  };
+  const nestedWorkflow = async (name: string, nestedArgs?: unknown) => {
+    const nested = options.loadSavedWorkflow?.(name);
+    if (!nested) throw new Error(`Saved workflow "${name}" was not found.`);
+    const result = await executeWorkflow(nested, nestedArgs, { ...options, runId: `${options.runId}-${name}`, resumeJournal: [] });
+    return result.result;
+  };
+
+  const context = vm.createContext({
+    agent,
+    parallel,
+    pipeline,
+    phase,
+    log,
+    retry,
+    gate,
+    checkpoint,
+    workflow: nestedWorkflow,
+    budget,
+    args,
+    cwd: options.cwd,
+    console: Object.freeze({ log }),
+  });
+  const executable = new vm.Script(`(async () => {\n"use strict";\n${body}\n})()`, {
+    filename: `workflow:${meta.name}`,
+  });
+  const result = await executable.runInContext(context, { timeout: 1000 });
+  if (callIndex === 0) throw new Error("Workflow scripts must call agent() at least once.");
+  assertJsonSerializable(result);
+  snapshot.result = result;
+  snapshot.durationMs = Date.now() - started;
+  update();
+  return {
+    meta,
+    result,
+    agentCount: snapshot.agentCount,
+    durationMs: snapshot.durationMs,
+    tokens: snapshot.tokens,
+    cost: snapshot.cost,
+    journal: journal.sort((a, b) => a.callIndex - b.callIndex),
+  };
+}
+
+async function runAgent(prompt: string, options: AgentCallOptions, run: ExecuteOptions): Promise<AgentRunResult> {
+  const requested = options.model ?? (options.tier ? loadModelTierConfig().tiers[options.tier] : undefined) ?? run.mainModel;
+  if (!requested) throw new Error("No model route was selected for this workflow agent.");
+  const resolved = resolveModel(requested, run.modelRuntime);
+  if (!resolved) throw new Error(`Workflow model "${requested}" is unavailable.`);
+  const { model, thinking, spec } = resolved;
+  const sessionManager = SessionManager.inMemory();
+  const agentDir = getAgentDir();
+  const settingsManager = SettingsManager.create(run.cwd, agentDir);
+  const resourceLoader = new DefaultResourceLoader({
+    cwd: run.cwd,
+    agentDir,
+    settingsManager,
+    noExtensions: true,
+  });
+  await resourceLoader.reload();
+  const { session } = await createAgentSession({
+    cwd: run.cwd,
+    model,
+    thinkingLevel: thinking,
+    modelRuntime: run.modelRuntime,
+    resourceLoader,
+    sessionManager,
+    settingsManager,
+    ...(options.tools ? { tools: options.tools } : {}),
+    ...(options.disallowedTools ? { excludeTools: options.disallowedTools } : {}),
+  });
+  const abort = () => void session.abort();
+  run.signal.addEventListener("abort", abort, { once: true });
+  try {
+    await session.prompt(prompt, { source: "extension" });
+    const output = lastAssistantText(session.messages);
+    if (!output) throw new Error("Subagent returned no text result.");
+    const stats = session.getSessionStats();
+    return { output, model: spec, tokens: stats.tokens.total, cost: stats.cost };
+  } finally {
+    run.signal.removeEventListener("abort", abort);
+    session.dispose();
+  }
+}
+
+function resolveModel(
+  requested: string,
+  runtime: ModelRuntime | undefined,
+): { model: Model<any>; thinking: ThinkingLevel; spec: string } | undefined {
+  if (!runtime) return undefined;
+  let spec = requested;
+  let thinking: ThinkingLevel = "medium";
+  const suffix = requested.match(/:(minimal|low|medium|high|xhigh|max)$/);
+  if (suffix) {
+    thinking = suffix[1] as ThinkingLevel;
+    spec = requested.slice(0, -suffix[0].length);
+  }
+  const slash = spec.indexOf("/");
+  if (slash < 1) return undefined;
+  const model = runtime.getModel(spec.slice(0, slash), spec.slice(slash + 1));
+  return model ? { model, thinking, spec: `${spec}:${thinking}` } : undefined;
+}
+
+function lastAssistantText(messages: readonly any[]): string {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role !== "assistant") continue;
+    if (message.stopReason === "error") throw new Error(message.errorMessage ?? "Subagent request failed.");
+    if (typeof message.content === "string") return message.content;
+    if (Array.isArray(message.content)) {
+      return message.content
+        .filter((part: any) => part?.type === "text" && typeof part.text === "string")
+        .map((part: any) => part.text)
+        .join("\n");
+    }
+  }
+  return "";
+}
+
+function literalValue(node: any): unknown {
+  switch (node.type) {
+    case "Literal":
+      return node.value;
+    case "ObjectExpression": {
+      const object: Record<string, unknown> = {};
+      for (const property of node.properties) {
+        if (property.type !== "Property" || property.computed || property.kind !== "init") {
+          throw new Error("Workflow meta must contain plain literal properties.");
+        }
+        const key = property.key.type === "Identifier" ? property.key.name : property.key.value;
+        if (typeof key !== "string") throw new Error("Workflow meta keys must be strings.");
+        object[key] = literalValue(property.value);
+      }
+      return object;
+    }
+    case "ArrayExpression":
+      return node.elements.map((element: any) => literalValue(element));
+    case "TemplateLiteral":
+      if (node.expressions.length) throw new Error("Workflow meta templates cannot contain expressions.");
+      return node.quasis.map((part: any) => part.value.cooked).join("");
+    default:
+      throw new Error("Workflow meta values must be literals.");
+  }
+}
+
+function createSnapshot(meta: WorkflowMeta): WorkflowSnapshot {
+  return {
+    name: meta.name,
+    description: meta.description,
+    phases: meta.phases?.map((phase) => phase.title) ?? [],
+    currentPhase: meta.phases?.[0]?.title,
+    agents: [],
+    logs: [],
+    agentCount: 0,
+    runningCount: 0,
+    doneCount: 0,
+    errorCount: 0,
+    tokens: 0,
+    cost: 0,
+  };
+}
+
+function recompute(snapshot: WorkflowSnapshot): void {
+  snapshot.agentCount = snapshot.agents.length;
+  snapshot.runningCount = snapshot.agents.filter((agent) => agent.status === "running").length;
+  snapshot.doneCount = snapshot.agents.filter((agent) => agent.status === "done").length;
+  snapshot.errorCount = snapshot.agents.filter((agent) => agent.status === "error").length;
+  snapshot.tokens = snapshot.agents.reduce((sum, agent) => sum + (agent.tokens ?? 0), 0);
+  snapshot.cost = snapshot.agents.reduce((sum, agent) => sum + (agent.cost ?? 0), 0);
+}
+
+function hashCall(prompt: string, options: AgentCallOptions): string {
+  return createHash("sha256").update(JSON.stringify({ prompt, options })).digest("hex");
+}
+
+function workflowRunsDir(cwd: string): string {
+  const key = createHash("sha256").update(cwd).digest("hex").slice(0, 16);
+  return join(homedir(), ".pi", "workflows", "projects", key, "runs");
+}
+
+function modelTierPath(): string {
+  return join(homedir(), ".pi", "workflows", "model-tiers.json");
+}
+
+function clampInteger(value: number | undefined, min: number, max: number, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.floor(value)));
+}
+
+function abortError(reason: unknown): Error {
+  return reason instanceof Error ? reason : new Error("Workflow aborted.");
+}
+
+function isSafeRunId(runId: string): boolean {
+  return /^[a-z0-9][a-z0-9-]{0,127}$/i.test(runId);
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid < 1) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function progressText(snapshot: WorkflowSnapshot): string {
+  return `${snapshot.name}: ${snapshot.doneCount}/${snapshot.agentCount} agents complete${snapshot.currentPhase ? ` · ${snapshot.currentPhase}` : ""}`;
+}
+
+function assertJsonSerializable(value: unknown): void {
+  if (value === undefined) return;
+  try {
+    if (JSON.stringify(value) === undefined) throw new Error("value has no JSON representation");
+  } catch (error) {
+    throw new Error(
+      `Workflow result must be JSON-serializable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+class Semaphore {
+  private active = 0;
+  private readonly queue: Array<() => void> = [];
+
+  constructor(private readonly limit: number) {}
+
+  async run<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.active >= this.limit) await new Promise<void>((resolve) => this.queue.push(resolve));
+    this.active++;
+    try {
+      return await operation();
+    } finally {
+      this.active--;
+      this.queue.shift()?.();
+    }
+  }
+}

--- a/extensions/workflow/runtime.ts
+++ b/extensions/workflow/runtime.ts
@@ -167,6 +167,8 @@ interface AgentCallOptions {
   disallowedTools?: string[];
 }
 
+type WorkflowAgentHandle = ((task: string, options?: AgentCallOptions) => Promise<unknown>) & PromiseLike<unknown>;
+
 interface AgentRunResult {
   output: string;
   model: string;
@@ -490,7 +492,7 @@ export function createWorkflowTool(options: { cwd?: string; manager: WorkflowMan
     promptGuidelines: [
       "Use workflow only when the user explicitly asks for a workflow, fan-out, or multi-agent orchestration.",
       "Pass raw JavaScript in script, beginning with export const meta = { name, description, phases: [{ title: 'Inspect' }] }.",
-      "Available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), retry(thunk, { attempts }), gate(thunk, validator, { attempts }), checkpoint(question), budget, args, and cwd.",
+      "Available globals are agent(prompt, opts), agent(persona, opts)(task), parallel(thunks), pipeline(items, ...stages), phase(title, optionalCallback), log(message), retry(thunk, { attempts }), gate(thunk, validator, { attempts }), checkpoint(question), budget, args, and cwd.",
       "parallel() receives functions, not promises: await parallel(items.map(item => () => agent(...))).",
       "Every agent needs a unique short label and a semantic opts.tier. End with one synthesizer agent and return a compact JSON-serializable result.",
       "Do not use imports, require, process, filesystem APIs, Date.now, Math.random, or new Date in workflow JavaScript.",
@@ -583,8 +585,12 @@ export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body:
     });
   }
   const remaining = program.body.slice(1);
-  const defaultRun = remaining.length === 1 ? remaining[0] : undefined;
-  const runDeclaration = defaultRun?.type === "ExportDefaultDeclaration" ? defaultRun.declaration : undefined;
+  const onlyStatement = remaining.length === 1 ? remaining[0] : undefined;
+  const runDeclaration = onlyStatement?.type === "ExportDefaultDeclaration"
+    ? onlyStatement.declaration
+    : onlyStatement?.type === "FunctionDeclaration" && onlyStatement.id?.name === "run"
+      ? onlyStatement
+      : undefined;
   const runBody =
     (runDeclaration?.type === "FunctionDeclaration" || runDeclaration?.type === "FunctionExpression") &&
     runDeclaration.body?.type === "BlockStatement"
@@ -592,18 +598,27 @@ export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body:
       : runDeclaration?.type === "ArrowFunctionExpression" && runDeclaration.body?.type === "BlockStatement"
         ? runDeclaration.body
         : undefined;
+  const trailing = remaining.at(-1);
+  const callsRun = trailing?.type === "ExpressionStatement"
+    && trailing.expression?.type === "CallExpression"
+    && trailing.expression.callee?.type === "Identifier"
+    && trailing.expression.callee.name === "run"
+    && trailing.expression.arguments?.length === 0;
+  const topLevelBody = callsRun
+    ? `${script.slice(first.end, trailing.start)}return await run();${script.slice(trailing.end)}`
+    : `${script.slice(0, first.start)}${script.slice(first.end)}`;
   return {
     meta: { name: meta.name.trim(), description: meta.description.trim(), phases },
     body: runBody
       ? script.slice(runBody.start + 1, runBody.end - 1)
-      : `${script.slice(0, first.start)}${script.slice(first.end)}`,
+      : topLevelBody,
   };
 }
 
 export function buildForcedWorkflowPrompt(prompt: string, directive?: string): string {
   return [
     "The user explicitly requested a dynamic workflow. You must call the workflow tool exactly once.",
-    "Design the JavaScript orchestration, then pass it as the tool's script argument. Metadata phases must use [{ title: 'Phase name' }]. Write orchestration as top-level statements or an export default async function run(). Do not perform the task with ordinary tools in this parent turn.",
+    "Design the JavaScript orchestration, then pass it as the tool's script argument. Metadata phases must use [{ title: 'Phase name' }]. Prefer top-level orchestration with phase('Name'); then await agent('complete task prompt', { label: 'name', tier: 'scout' }). agent() may also define a reusable persona that is later called with a task, and phase('Name', async () => ...) is accepted. If using a run() function, export it as default or finish with await run(). Do not perform the task with ordinary tools in this parent turn.",
     directive ?? "",
     "User request:",
     prompt,
@@ -685,7 +700,7 @@ async function executeWorkflow(script: string, args: unknown, options: ExecuteOp
     options.onProgress?.(structuredClone(snapshot));
   };
 
-  const agent = async (prompt: string, callOptions: AgentCallOptions = {}): Promise<unknown> => {
+  const spawnAgent = async (prompt: string, callOptions: AgentCallOptions = {}): Promise<unknown> => {
     if (options.signal.aborted) throw abortError(options.signal.reason);
     const index = callIndex++;
     if (index >= maxAgents) throw new Error(`Workflow exceeded its ${maxAgents}-agent cap.`);
@@ -757,6 +772,17 @@ async function executeWorkflow(script: string, args: unknown, options: ExecuteOp
     });
   };
 
+  const agent = (prompt: string, callOptions: AgentCallOptions = {}): WorkflowAgentHandle => {
+    let direct: Promise<unknown> | undefined;
+    const handle = ((task: string, overrides: AgentCallOptions = {}) =>
+      spawnAgent(`${prompt}\n\nTask:\n${String(task)}`, { ...callOptions, ...overrides })) as WorkflowAgentHandle;
+    handle.then = (onfulfilled, onrejected) => {
+      direct ??= spawnAgent(prompt, callOptions);
+      return direct.then(onfulfilled, onrejected);
+    };
+    return handle;
+  };
+
   const parallel = async (thunks: Array<() => Promise<unknown>>): Promise<unknown[]> => Promise.all(thunks.map((fn) => fn()));
   const pipeline = async (items: unknown[], ...stages: Array<(value: unknown, original: unknown, index: number) => unknown>) =>
     Promise.all(
@@ -766,11 +792,12 @@ async function executeWorkflow(script: string, args: unknown, options: ExecuteOp
         return value;
       }),
     );
-  const phase = (title: string) => {
+  const phase = <T>(title: string, operation?: () => T | Promise<T>): T | Promise<T> | undefined => {
     currentPhase = title;
     snapshot.currentPhase = title;
     snapshot.logs.push(`phase: ${title}`);
     update();
+    return typeof operation === "function" ? operation() : undefined;
   };
   const log = (message: unknown) => {
     snapshot.logs.push(String(message));

--- a/extensions/workflow/types.ts
+++ b/extensions/workflow/types.ts
@@ -1,0 +1,56 @@
+export const WORKFLOW_PROFILE_NAMES = ["lean", "balanced", "deep", "custom"] as const;
+export type WorkflowProfileName = (typeof WORKFLOW_PROFILE_NAMES)[number];
+
+export const WORKFLOW_ROLES = ["scout", "worker", "reviewer", "synthesizer"] as const;
+export type WorkflowRole = (typeof WORKFLOW_ROLES)[number];
+
+export const WORKFLOW_THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
+export type WorkflowThinkingLevel = (typeof WORKFLOW_THINKING_LEVELS)[number];
+
+export type WorkflowApprovalMode = "always" | "generated";
+
+export interface WorkflowRoleRoute {
+  model: string;
+  thinking: WorkflowThinkingLevel;
+}
+
+export interface WorkflowControlSettings {
+  version: 1;
+  profile: WorkflowProfileName;
+  routes: Record<WorkflowRole, WorkflowRoleRoute>;
+  concurrency: number;
+  maxAgents: number;
+  approvalMode: WorkflowApprovalMode;
+}
+
+export interface WorkflowModelCandidate {
+  spec: string;
+  provider: string;
+  name: string;
+  costOutput: number;
+  contextWindow: number;
+}
+
+export interface SavedWorkflowFile {
+  id: string;
+  name: string;
+  description: string;
+  phases: string[];
+  path: string;
+  location: "project" | "user" | "built-in";
+  script: string;
+}
+
+export interface WorkflowPreview {
+  name: string;
+  description: string;
+  phases: string[];
+  staticAgentCalls: number;
+  explicitModels: string[];
+  explicitTools: string[];
+  profile: WorkflowProfileName;
+  routes: Record<WorkflowRole, WorkflowRoleRoute>;
+  concurrency: number;
+  maxAgents: number;
+  source: "generated" | "saved";
+}

--- a/extensions/workflow/types.ts
+++ b/extensions/workflow/types.ts
@@ -44,6 +44,7 @@ export interface SavedWorkflowFile {
 export interface WorkflowPreview {
   name: string;
   description: string;
+  script: string;
   phases: string[];
   staticAgentCalls: number;
   explicitModels: string[];

--- a/extensions/workflow/ui.ts
+++ b/extensions/workflow/ui.ts
@@ -1,0 +1,66 @@
+import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { deliverText, renderPanel, type WorkflowManager } from "./runtime.js";
+
+type DeliveryManager = WorkflowManager & {
+  __piWorkflowDeliveryInstalled?: boolean;
+  __piWorkflowDeliveryApi?: ExtensionAPI;
+};
+
+export function installWorkflowResultDelivery(pi: ExtensionAPI, manager: WorkflowManager): void {
+  const shared = manager as DeliveryManager;
+  shared.__piWorkflowDeliveryApi = pi;
+  if (shared.__piWorkflowDeliveryInstalled) return;
+  shared.__piWorkflowDeliveryInstalled = true;
+
+  const deliver = (content: string) => {
+    try {
+      const result = shared.__piWorkflowDeliveryApi?.sendMessage(
+        { customType: "workflow-result", content, display: true },
+        { triggerTurn: true, deliverAs: "followUp" },
+      );
+      void Promise.resolve(result).catch(() => {});
+    } catch {
+      // The persisted run remains available through /workflow history.
+    }
+  };
+
+  manager.on("complete", ({ runId }: { runId: string }) => {
+    const run = manager.getRun(runId);
+    if (run?.background) deliver(deliverText(run));
+  });
+  manager.on("error", ({ runId, error }: { runId: string; error?: Error }) => {
+    if (manager.getRun(runId)?.background) {
+      deliver(`✗ Background workflow ${runId} failed: ${error?.message ?? "unknown error"}`);
+    }
+  });
+  manager.on(
+    "paused",
+    ({ runId, reason, error, resetHint }: { runId: string; reason?: string; error?: Error; resetHint?: string }) => {
+      if (reason !== "usage_limit" || !manager.getRun(runId)?.background) return;
+      const when = resetHint ? ` (${resetHint})` : "";
+      deliver(
+        `⏸ Background workflow ${runId} paused: ${error?.message ?? "provider usage limit reached"}${when}. ` +
+          `Completed steps are saved — run /workflow resume ${runId} after the limit resets.`,
+      );
+    },
+  );
+}
+
+export function installWorkflowTaskPanel(manager: WorkflowManager, ui: ExtensionUIContext): void {
+  ui.setWidget("workflow-tasks", (tui, theme) => {
+    const render = () => tui.requestRender();
+    const events = ["agentStart", "agentEnd", "phase", "complete", "error", "paused", "stopped"];
+    for (const event of events) manager.on(event, render);
+    return {
+      render(width: number) {
+        return renderPanel(manager, theme, width).map((line) =>
+          line.replace("/workflows — open navigator", "/workflow active — inspect runs"),
+        );
+      },
+      invalidate() {},
+      dispose() {
+        for (const event of events) manager.off(event, render);
+      },
+    };
+  });
+}

--- a/extensions/workflow/ui.ts
+++ b/extensions/workflow/ui.ts
@@ -16,7 +16,7 @@ export function installWorkflowResultDelivery(pi: ExtensionAPI, manager: Workflo
     try {
       const result = shared.__piWorkflowDeliveryApi?.sendMessage(
         { customType: "workflow-result", content, display: true },
-        { triggerTurn: true, deliverAs: "followUp" },
+        { triggerTurn: false },
       );
       void Promise.resolve(result).catch(() => {});
     } catch {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,25 @@
       "name": "pi-agent-extensions",
       "version": "0.4.6",
       "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "typebox": "1.1.38"
+      },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-coding-agent": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-coding-agent": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@sinclair/typebox": "^0.34.48",
-        "tsx": "^4.21.0"
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*",
-        "@earendil-works/pi-tui": "*"
+        "@earendil-works/pi-ai": ">=0.80.10",
+        "@earendil-works/pi-coding-agent": ">=0.80.10",
+        "@earendil-works/pi-tui": ">=0.80.10"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -511,10 +516,26 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
+      "integrity": "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.80.10",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
-      "integrity": "sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -606,16 +627,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.2.tgz",
-      "integrity": "sha512-m9v7OUit0s9LklWfh61ca/XY5INjUzjtYtNZwy3cNvyjOLk3IpBgghP8aAp0iH35rLaiRwuuWiJ8t88ODMWY+A==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
       "dev": true,
-      "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.2",
-        "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -640,546 +660,6 @@
       },
       "optionalDependencies": {
         "@mariozechner/clipboard": "0.3.9"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1048.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
-      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/credential-provider-node": "^3.972.42",
-        "@aws-sdk/eventstream-handler-node": "^3.972.16",
-        "@aws-sdk/middleware-eventstream": "^3.972.12",
-        "@aws-sdk/middleware-websocket": "^3.972.19",
-        "@aws-sdk/token-providers": "3.1048.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
-      "version": "3.974.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
-      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.24",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
-      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
-      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
-      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/credential-provider-env": "^3.972.37",
-        "@aws-sdk/credential-provider-http": "^3.972.39",
-        "@aws-sdk/credential-provider-login": "^3.972.41",
-        "@aws-sdk/credential-provider-process": "^3.972.37",
-        "@aws-sdk/credential-provider-sso": "^3.972.41",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
-      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
-      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.37",
-        "@aws-sdk/credential-provider-http": "^3.972.39",
-        "@aws-sdk/credential-provider-ini": "^3.972.41",
-        "@aws-sdk/credential-provider-process": "^3.972.37",
-        "@aws-sdk/credential-provider-sso": "^3.972.41",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
-      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
-      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/token-providers": "3.1048.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
-      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
-      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
-      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
-      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
-      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
-      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1048.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
-      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
-      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.2.tgz",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.2",
-        "ignore": "7.0.5",
-        "typebox": "1.1.38",
-        "yaml": "2.9.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
-        "@smithy/node-http-handler": "4.7.3",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
-        "partial-json": "0.1.7",
-        "typebox": "1.1.38"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "1.6.0",
-        "marked": "18.0.5"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
@@ -1387,281 +867,12 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
       "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
-      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
-      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
-      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -1672,44 +883,6 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
       "version": "5.0.6",
@@ -1724,13 +897,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -1744,49 +910,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -1795,142 +918,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
@@ -1949,34 +936,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
@@ -2009,51 +968,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -2064,60 +978,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
       "version": "11.4.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
@@ -2126,19 +986,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
@@ -2165,129 +1012,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
@@ -2329,61 +1053,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -2397,69 +1066,12 @@
         "node": ">=10"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
       "version": "8.5.0",
@@ -2471,117 +1083,10 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
-      "integrity": "sha512-OvOAMIbXiC9OSse17YMiXIsI9AS5XM/ZV8N/k+UzdlRpPILDQYmLElevgGW92kkXR8qHBClIdzhCjuzlBGvphA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3247,13 +1752,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -3428,6 +1926,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3510,9 +2020,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3911,6 +2421,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4009,6 +2529,22 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minipass": {
@@ -4133,9 +2669,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
-      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -4146,7 +2682,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -4211,22 +2746,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/rimraf/node_modules/path-scurry": {
       "version": "1.11.1",
@@ -4398,8 +2917,21 @@
       "version": "1.1.38",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
       "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.24.6",
@@ -4454,9 +2986,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4489,6 +3021,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.19.0"
       },
       "peerDependencies": {
         "@earendil-works/pi-ai": ">=0.80.10",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/jayshah5696"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.19.0"
   },
   "pi": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
       "./extensions/todos/index.ts",
       "./extensions/whimsical/index.ts",
       "./extensions/btw/index.ts",
-      "./extensions/powerline-footer/index.ts"
+      "./extensions/powerline-footer/index.ts",
+      "./extensions/workflow/index.ts"
     ],
     "themes": [
       "./themes/nightowl.json",
@@ -57,20 +58,27 @@
     ]
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*"
+    "@earendil-works/pi-ai": ">=0.80.10",
+    "@earendil-works/pi-coding-agent": ">=0.80.10",
+    "@earendil-works/pi-tui": ">=0.80.10"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.80.2",
-    "@earendil-works/pi-coding-agent": "^0.80.2",
-    "@earendil-works/pi-tui": "^0.80.2",
+    "@earendil-works/pi-ai": "^0.80.10",
+    "@earendil-works/pi-coding-agent": "^0.80.10",
+    "@earendil-works/pi-tui": "^0.80.10",
     "@sinclair/typebox": "^0.34.48",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
   },
   "scripts": {
     "test": "node --import tsx --test 'tests/**/*.test.ts' 'tests/*.test.ts'",
+    "test:workflow": "node --import tsx --test 'tests/workflow/**/*.test.ts'",
+    "typecheck:workflow": "tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict extensions/workflow/*.ts tests/workflow/*.ts",
     "release:check": "./scripts/check-release.sh",
     "release:publish": "./scripts/publish-release.sh"
+  },
+  "dependencies": {
+    "acorn": "^8.16.0",
+    "typebox": "1.1.38"
   }
 }

--- a/tests/workflow/approval.test.ts
+++ b/tests/workflow/approval.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { WorkflowApprovalView } from "../../extensions/workflow/approval.js";
+import type { WorkflowPreview } from "../../extensions/workflow/types.js";
+
+const script = `export const meta = {
+  name: "visible-plan",
+  description: "Show the code before approval",
+  phases: [{ title: "Inspect" }]
+};
+phase("Inspect");
+return await agent("Inspect the repository.", { label: "inspector", tier: "scout" });`;
+
+const preview: WorkflowPreview = {
+  name: "visible-plan",
+  description: "Show the code before approval",
+  script,
+  phases: ["Inspect"],
+  staticAgentCalls: 1,
+  explicitModels: [],
+  explicitTools: [],
+  profile: "lean",
+  concurrency: 3,
+  maxAgents: 8,
+  source: "generated",
+  routes: {
+    scout: { model: "test/small", thinking: "low" },
+    worker: { model: "test/medium", thinking: "medium" },
+    reviewer: { model: "test/reviewer", thinking: "medium" },
+    synthesizer: { model: "test/large", thinking: "high" },
+  },
+};
+
+describe("workflow approval view", () => {
+  it("shows the actual JavaScript by default and requires an explicit y approval", () => {
+    let approved: boolean | undefined;
+    const tui = { terminal: { rows: 36 }, requestRender() {} } as any;
+    const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text } as any;
+    const view = new WorkflowApprovalView(tui, theme, preview, (result) => { approved = result; });
+    const rendered = view.render(110).join("\n");
+
+    assert.match(rendered, /\[JavaScript\]/);
+    assert.match(rendered, /return await agent/);
+    assert.match(rendered, /y approve and run/);
+    assert.equal(approved, undefined);
+    view.handleInput("y");
+    assert.equal(approved, true);
+  });
+
+  it("lets the user switch to the route and security summary or reject", () => {
+    let approved: boolean | undefined;
+    const tui = { terminal: { rows: 36 }, requestRender() {} } as any;
+    const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text } as any;
+    const view = new WorkflowApprovalView(tui, theme, preview, (result) => { approved = result; });
+    view.handleInput("\t");
+    const rendered = view.render(110).join("\n");
+    assert.match(rendered, /Profile: lean/);
+    assert.match(rendered, /not [\s│]*a security sandbox/);
+    view.handleInput("n");
+    assert.equal(approved, false);
+  });
+});

--- a/tests/workflow/config.test.ts
+++ b/tests/workflow/config.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+  loadWorkflowControlSettings,
+  profileLimits,
+  saveWorkflowControlSettings,
+} from "../../extensions/workflow/config.js";
+import type { WorkflowControlSettings } from "../../extensions/workflow/types.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function settings(profile: WorkflowControlSettings["profile"] = "balanced"): WorkflowControlSettings {
+  return {
+    version: 1,
+    profile,
+    concurrency: 4,
+    maxAgents: 15,
+    approvalMode: "always",
+    routes: {
+      scout: { model: "provider/small", thinking: "low" },
+      worker: { model: "provider/medium", thinking: "medium" },
+      reviewer: { model: "other/reviewer", thinking: "high" },
+      synthesizer: { model: "provider/large", thinking: "high" },
+    },
+  };
+}
+
+describe("workflow control settings", () => {
+  it("saves and loads global settings", () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-config-"));
+    roots.push(root);
+    const paths = { globalPath: join(root, "global.json"), projectPath: join(root, "project.json") };
+    saveWorkflowControlSettings(settings(), root, "global", paths);
+    assert.deepEqual(loadWorkflowControlSettings(root, paths), settings());
+  });
+
+  it("lets a valid project profile override the global profile", () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-config-"));
+    roots.push(root);
+    const paths = { globalPath: join(root, "global.json"), projectPath: join(root, "project.json") };
+    saveWorkflowControlSettings(settings("balanced"), root, "global", paths);
+    saveWorkflowControlSettings({ ...settings("lean"), concurrency: 3, maxAgents: 8 }, root, "project", paths);
+    assert.equal(loadWorkflowControlSettings(root, paths)?.profile, "lean");
+  });
+
+  it("ignores corrupt and incomplete settings", () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-config-"));
+    roots.push(root);
+    const globalPath = join(root, "global.json");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(globalPath, JSON.stringify({ profile: "balanced", routes: {} }));
+    assert.equal(loadWorkflowControlSettings(root, { globalPath, projectPath: join(root, "missing") }), undefined);
+  });
+
+  it("defines the intended preset limits", () => {
+    assert.deepEqual(profileLimits("lean"), { concurrency: 3, maxAgents: 8 });
+    assert.deepEqual(profileLimits("balanced"), { concurrency: 4, maxAgents: 15 });
+    assert.deepEqual(profileLimits("deep"), { concurrency: 6, maxAgents: 40 });
+  });
+});

--- a/tests/workflow/discovery-preview.test.ts
+++ b/tests/workflow/discovery-preview.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { discoverWorkflowFiles, loadWorkflowFile } from "../../extensions/workflow/discovery.js";
+import { createWorkflowPreview, applyWorkflowLimits, formatWorkflowApproval } from "../../extensions/workflow/preview.js";
+import type { WorkflowControlSettings } from "../../extensions/workflow/types.js";
+
+const roots: string[] = [];
+const script = `export const meta = {
+  name: "review",
+  description: "Review the change",
+  phases: [{ title: "Inspect" }, { title: "Synthesize" }]
+};
+const result = await agent("inspect", { label: "inspector", tier: "reviewer", tools: ["read", "bash"], model: "other/reviewer" });
+return { result };
+`;
+const settings: WorkflowControlSettings = {
+  version: 1,
+  profile: "balanced",
+  concurrency: 4,
+  maxAgents: 15,
+  approvalMode: "always",
+  routes: {
+    scout: { model: "provider/small", thinking: "low" },
+    worker: { model: "provider/medium", thinking: "medium" },
+    reviewer: { model: "other/reviewer", thinking: "high" },
+    synthesizer: { model: "provider/large", thinking: "high" },
+  },
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("saved workflow discovery", () => {
+  it("ships parseable built-in workflows", () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-builtins-"));
+    roots.push(root);
+    const projectDir = join(root, "project");
+    const userDir = join(root, "user");
+    mkdirSync(projectDir);
+    mkdirSync(userDir);
+    const workflows = discoverWorkflowFiles(root, { projectDir, userDir });
+    assert.deepEqual(
+      workflows.filter((workflow) => workflow.location === "built-in").map((workflow) => workflow.id),
+      ["code-review", "migration-plan", "repository-audit"],
+    );
+  });
+
+  it("discovers plain JavaScript and lets project files override user files", () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-discovery-"));
+    roots.push(root);
+    const projectDir = join(root, "project");
+    const userDir = join(root, "user");
+    mkdirSync(projectDir);
+    mkdirSync(userDir);
+    writeFileSync(join(userDir, "review.js"), script.replace("Review the change", "User review"));
+    writeFileSync(join(projectDir, "review.js"), script.replace("Review the change", "Project review"));
+    writeFileSync(join(projectDir, "broken.js"), "not javascript");
+
+    const options = { projectDir, userDir, builtInDir: null };
+    const workflows = discoverWorkflowFiles(root, options);
+    assert.equal(workflows.length, 1);
+    assert.equal(workflows[0].description, "Project review");
+    assert.equal(loadWorkflowFile(root, "review", options)?.location, "project");
+  });
+});
+
+describe("workflow approval preview", () => {
+  it("shows phases, routes, explicit models, tools, and bounded scale", () => {
+    const limited = applyWorkflowLimits({ script, maxAgents: 100, concurrency: 12 }, settings);
+    assert.equal(limited.maxAgents, 15);
+    assert.equal(limited.concurrency, 4);
+    const preview = createWorkflowPreview(script, settings, "generated", limited);
+    assert.deepEqual(preview.phases, ["Inspect", "Synthesize"]);
+    assert.deepEqual(preview.explicitModels, ["other/reviewer"]);
+    assert.deepEqual(preview.explicitTools, ["read", "bash"]);
+    assert.match(formatWorkflowApproval(preview), /not a security sandbox/);
+  });
+});

--- a/tests/workflow/discovery-preview.test.ts
+++ b/tests/workflow/discovery-preview.test.ts
@@ -77,6 +77,18 @@ describe("workflow approval preview", () => {
     assert.deepEqual(preview.phases, ["Inspect", "Synthesize"]);
     assert.deepEqual(preview.explicitModels, ["other/reviewer"]);
     assert.deepEqual(preview.explicitTools, ["read", "bash"]);
+    assert.equal(preview.script, script);
     assert.match(formatWorkflowApproval(preview), /not a security sandbox/);
+  });
+
+  it("rejects a generated plan with no executable agent call before approval", () => {
+    assert.throws(
+      () => createWorkflowPreview(
+        `export const meta = { name: "empty", description: "No work" };\nreturn "nothing";`,
+        settings,
+        "generated",
+      ),
+      /preflight failed.*does not call agent/i,
+    );
   });
 });

--- a/tests/workflow/extension.test.ts
+++ b/tests/workflow/extension.test.ts
@@ -51,6 +51,7 @@ describe("workflow extension registration", () => {
       modelRegistry: {
         getRegisteredProviderIds: () => [],
         getRegisteredProviderConfig: () => undefined,
+        getAvailable: () => [],
       },
       sessionManager: { getSessionId: () => "session-1" },
       mode: "print",
@@ -65,5 +66,11 @@ describe("workflow extension registration", () => {
 
     await commands.get("workflow")("help", { ui: { notify() {} } });
     assert.match(messages.at(-1) ?? "", /\/workflow setup/);
+
+    const beforeDoctor = messages.length;
+    await commands.get("workflow")("doctor", context);
+    assert.equal(messages.length, beforeDoctor + 1);
+    assert.match(messages.at(-1) ?? "", /Workflow doctor — read-only readiness check/);
+    assert.match(messages.at(-1) ?? "", /made no model calls.*started no workflows/);
   });
 });

--- a/tests/workflow/extension.test.ts
+++ b/tests/workflow/extension.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { createWorkflowExtension } from "../../extensions/workflow/index.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("workflow extension registration", () => {
+  it("registers the singular command and activates the tool only for trusted projects", async () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-extension-"));
+    roots.push(root);
+    const commands = new Map<string, any>();
+    const tools = new Map<string, any>();
+    const events = new Map<string, any>();
+    const messages: string[] = [];
+    let activeTools: string[] = ["read"];
+    const pi = {
+      registerCommand(name: string, options: any) {
+        commands.set(name, options.handler);
+      },
+      registerTool(tool: any) {
+        tools.set(tool.name, tool);
+      },
+      on(event: string, handler: any) {
+        events.set(event, handler);
+      },
+      getActiveTools() {
+        return activeTools;
+      },
+      setActiveTools(next: string[]) {
+        activeTools = next;
+      },
+      sendMessage(message: { content: string }) {
+        messages.push(message.content);
+      },
+    } as any;
+
+    createWorkflowExtension({ cwd: root, runsDir: join(root, "runs") })(pi);
+    assert.ok(commands.has("workflow"));
+    assert.ok(tools.has("workflow"));
+    assert.ok(events.has("session_start"));
+
+    const context = {
+      model: undefined,
+      modelRegistry: {
+        getRegisteredProviderIds: () => [],
+        getRegisteredProviderConfig: () => undefined,
+      },
+      sessionManager: { getSessionId: () => "session-1" },
+      mode: "print",
+      ui: { setWidget() {} },
+      isProjectTrusted: () => false,
+    };
+    events.get("session_start")({}, context);
+    assert.deepEqual(activeTools, ["read"]);
+    context.isProjectTrusted = () => true;
+    events.get("session_start")({}, context);
+    assert.deepEqual(activeTools, ["read", "workflow"]);
+
+    await commands.get("workflow")("help", { ui: { notify() {} } });
+    assert.match(messages.at(-1) ?? "", /\/workflow setup/);
+  });
+});

--- a/tests/workflow/help.test.ts
+++ b/tests/workflow/help.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { formatWorkflowDoctor, formatWorkflowHelp } from "../../extensions/workflow/help.js";
+import type { WorkflowControlSettings } from "../../extensions/workflow/types.js";
+
+const settings: WorkflowControlSettings = {
+  version: 1,
+  profile: "lean",
+  concurrency: 3,
+  maxAgents: 8,
+  approvalMode: "always",
+  routes: {
+    scout: { model: "test/scout", thinking: "low" },
+    worker: { model: "test/worker", thinking: "medium" },
+    reviewer: { model: "test/reviewer", thinking: "medium" },
+    synthesizer: { model: "test/synthesizer", thinking: "high" },
+  },
+};
+
+describe("workflow user guidance", () => {
+  it("explains the complete setup, approval, inspection, and verification path", () => {
+    const help = formatWorkflowHelp();
+    assert.match(help, /\/workflow setup/);
+    assert.match(help, /complete JavaScript approval screen/);
+    assert.match(help, /y runs · n\/Esc rejects/);
+    assert.match(help, /\/workflow history/);
+    assert.match(help, /\/workflow doctor.*no model calls/);
+    assert.match(help, /will not retry or ask for approval again/);
+  });
+
+  it("reports a ready installation and states that verification is side-effect free", () => {
+    const report = formatWorkflowDoctor({
+      extensionActive: true,
+      projectTrusted: true,
+      settings,
+      availableModels: 4,
+      missingRoles: [],
+      savedWorkflows: 3,
+      runHistory: 2,
+    });
+    assert.match(report, /✓ Workflow extension is active/);
+    assert.match(report, /✓ All 4 model routes are available/);
+    assert.match(report, /Ready\. Try:/);
+    assert.match(report, /made no model calls, changed no settings, and started no workflows/);
+  });
+
+  it("gives a concrete recovery step when trust or model routes are missing", () => {
+    const untrusted = formatWorkflowDoctor({
+      extensionActive: true,
+      projectTrusted: false,
+      settings,
+      availableModels: 4,
+      missingRoles: [],
+      savedWorkflows: 3,
+      runHistory: 0,
+    });
+    assert.match(untrusted, /restart Pi with --approve/i);
+
+    const missing = formatWorkflowDoctor({
+      extensionActive: true,
+      projectTrusted: true,
+      settings,
+      availableModels: 3,
+      missingRoles: ["reviewer"],
+      savedWorkflows: 3,
+      runHistory: 0,
+    });
+    assert.match(missing, /Unavailable model routes: reviewer/);
+    assert.match(missing, /Run \/workflow setup again/);
+  });
+});

--- a/tests/workflow/model-selector.test.ts
+++ b/tests/workflow/model-selector.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { filterWorkflowModels, WorkflowModelSelector } from "../../extensions/workflow/model-selector.js";
+import type { WorkflowModelCandidate } from "../../extensions/workflow/types.js";
+
+const models: WorkflowModelCandidate[] = [
+  { spec: "openrouter/anthropic/claude-opus", provider: "openrouter", name: "Claude Opus", costOutput: 10, contextWindow: 200_000 },
+  { spec: "openrouter/google/gemini-flash", provider: "openrouter", name: "Gemini Flash", costOutput: 1, contextWindow: 1_000_000 },
+  { spec: "openai/gpt-5.5", provider: "openai", name: "GPT 5.5", costOutput: 8, contextWindow: 400_000 },
+];
+
+describe("workflow model picker", () => {
+  it("filters by provider, model id, and display name like Pi's /model selector", () => {
+    assert.deepEqual(filterWorkflowModels(models, "gemini").map((model) => model.spec), [
+      "openrouter/google/gemini-flash",
+    ]);
+    assert.deepEqual(filterWorkflowModels(models, "openai 5.5").map((model) => model.spec), [
+      "openai/gpt-5.5",
+    ]);
+    assert.equal(filterWorkflowModels(models, "").length, 3);
+  });
+
+  it("renders a bounded searchable viewport instead of the full provider catalog", () => {
+    const catalog = Array.from({ length: 30 }, (_, index): WorkflowModelCandidate => ({
+      spec: `provider/model-${index}`,
+      provider: "provider",
+      name: `Model ${index}`,
+      costOutput: index,
+      contextWindow: 100_000,
+    }));
+    const selector = new WorkflowModelSelector(
+      { requestRender() {} } as any,
+      { fg: (_color: string, value: string) => value } as any,
+      "Scout model",
+      catalog,
+      "provider/model-15",
+      () => {},
+      () => {},
+    );
+    const rendered = selector.render(100).join("\n");
+    assert.match(rendered, /Scout model/);
+    assert.match(rendered, /Type to filter models/);
+    assert.equal((rendered.match(/provider\/model-/g) ?? []).length, 9);
+    assert.match(rendered, /16\/30/);
+  });
+});

--- a/tests/workflow/profiles.test.ts
+++ b/tests/workflow/profiles.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   rankModels,
+  scopeModelCandidates,
   suggestWorkflowSettings,
   toModelTierConfig,
   workflowRoleGuideline,
@@ -39,5 +40,22 @@ describe("workflow model profiles", () => {
     assert.equal(config.tiers.medium, config.tiers.worker);
     assert.equal(config.tiers.big, config.tiers.synthesizer);
     assert.match(workflowRoleGuideline(settings), /tier: 'reviewer'/);
+  });
+
+  it("limits setup choices to Pi's enabled model scope", () => {
+    const variants = [
+      ...models,
+      { spec: "openai/gpt-mid-mini", provider: "openai", name: "GPT Mid Mini", costOutput: 1, contextWindow: 128_000 },
+    ];
+    const scoped = scopeModelCandidates(
+      variants,
+      ["openai/gpt-mid", "anthropic/haiku:low"],
+      "anthropic/opus",
+    );
+    assert.deepEqual(scoped.map((model) => model.spec), [
+      "anthropic/opus",
+      "openai/gpt-mid",
+      "anthropic/haiku",
+    ]);
   });
 });

--- a/tests/workflow/profiles.test.ts
+++ b/tests/workflow/profiles.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  rankModels,
+  suggestWorkflowSettings,
+  toModelTierConfig,
+  workflowRoleGuideline,
+} from "../../extensions/workflow/profiles.js";
+import type { WorkflowModelCandidate } from "../../extensions/workflow/types.js";
+
+const models: WorkflowModelCandidate[] = [
+  { spec: "anthropic/haiku", provider: "anthropic", name: "Haiku", costOutput: 1, contextWindow: 200_000 },
+  { spec: "openai/gpt-mid", provider: "openai", name: "GPT Mid", costOutput: 5, contextWindow: 128_000 },
+  { spec: "anthropic/opus", provider: "anthropic", name: "Opus", costOutput: 20, contextWindow: 200_000 },
+];
+
+describe("workflow model profiles", () => {
+  it("ranks priced models from inexpensive to expensive", () => {
+    assert.deepEqual(rankModels(models).map((model) => model.spec), [
+      "anthropic/haiku",
+      "openai/gpt-mid",
+      "anthropic/opus",
+    ]);
+  });
+
+  it("builds a balanced role map with a cross-provider reviewer", () => {
+    const settings = suggestWorkflowSettings("balanced", models, "anthropic/opus");
+    assert.equal(settings.routes.scout.model, "anthropic/haiku");
+    assert.equal(settings.routes.worker.model, "anthropic/opus");
+    assert.equal(settings.routes.reviewer.model, "openai/gpt-mid");
+    assert.equal(settings.concurrency, 4);
+    assert.equal(settings.maxAgents, 15);
+  });
+
+  it("compiles semantic roles and compatibility aliases into runtime tiers", () => {
+    const settings = suggestWorkflowSettings("lean", models, "openai/gpt-mid");
+    const config = toModelTierConfig(settings);
+    assert.equal(config.tiers.small, config.tiers.scout);
+    assert.equal(config.tiers.medium, config.tiers.worker);
+    assert.equal(config.tiers.big, config.tiers.synthesizer);
+    assert.match(workflowRoleGuideline(settings), /tier: 'reviewer'/);
+  });
+});

--- a/tests/workflow/run-browser.test.ts
+++ b/tests/workflow/run-browser.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import {
+  exportWorkflowReport,
+  formatWorkflowRunSummary,
+  saveWorkflowScript,
+  WorkflowRunBrowser,
+  workflowResultMarkdown,
+} from "../../extensions/workflow/run-browser.js";
+import { deliverText, type ManagedRun, type PersistedRunState, WorkflowManager } from "../../extensions/workflow/runtime.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function completedRun(report = "# Final report\n\nUseful evidence."): PersistedRunState {
+  return {
+    runId: "research-run-abc123",
+    workflowName: "research-run",
+    status: "completed",
+    script: 'export const meta = { name: "research-run", description: "Research" };\nreturn agent("work");',
+    journal: [],
+    startedAt: "2026-07-18T18:00:00.000Z",
+    updatedAt: "2026-07-18T18:05:30.000Z",
+    snapshot: {
+      name: "research-run",
+      description: "Research",
+      phases: ["Research", "Synthesize"],
+      currentPhase: "Synthesize",
+      logs: ["phase: Research", "phase: Synthesize"],
+      agents: [],
+      agentCount: 1,
+      runningCount: 0,
+      doneCount: 1,
+      errorCount: 0,
+      tokens: 2_282_261,
+      cost: 1.9386,
+      durationMs: 330_000,
+      result: { report, supportingFindings: ["one"] },
+    },
+    agents: [
+      {
+        id: 1,
+        label: "synth",
+        status: "done",
+        phase: "Synthesize",
+        prompt: "Synthesize the evidence.",
+        model: "test/model:medium",
+        result: report,
+        tokens: 2_282_261,
+        cost: 1.9386,
+        activity: [{ type: "tool_call", name: "read", summary: '{"path":"README.md"}' }],
+      },
+    ],
+    result: {
+      meta: { name: "research-run", description: "Research" },
+      result: { report, supportingFindings: ["one"] },
+      agentCount: 1,
+      durationMs: 330_000,
+      tokens: 2_282_261,
+      cost: 1.9386,
+      journal: [],
+    },
+  };
+}
+
+describe("workflow run browser", () => {
+  it("renders the primary Markdown report and visible usage instead of escaped JSON", () => {
+    const run = completedRun();
+    assert.equal(workflowResultMarkdown(run), "# Final report\n\nUseful evidence.");
+    assert.match(formatWorkflowRunSummary(run), /2\.28M/);
+    assert.match(formatWorkflowRunSummary(run), /\$1\.9386/);
+
+    const delivery = deliverText({ ...run, controller: new AbortController(), background: true } as ManagedRun);
+    assert.match(delivery, /# Final report/);
+    assert.doesNotMatch(delivery, /\\n/);
+    assert.match(delivery, new RegExp(`/workflow status ${run.runId}`));
+  });
+
+  it("does not truncate a long completed report", () => {
+    const report = `# Long report\n\n${"evidence ".repeat(2_000)}`;
+    const run = completedRun(report);
+    assert.equal(workflowResultMarkdown(run).length, report.length);
+    assert.equal(deliverText({ ...run, controller: new AbortController(), background: true } as ManagedRun).includes(report), true);
+  });
+
+  it("exports durable Markdown and self-contained visual HTML", () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-export-"));
+    roots.push(root);
+    const run = completedRun("# Report\n\n<script>alert('no')</script>\n\n| Check | Result |\n| --- | --- |\n| Sources | Verified |\n\n**Verified.**");
+    const markdownPath = exportWorkflowReport(run, root, "markdown", join(root, "exports"));
+    const htmlPath = exportWorkflowReport(run, root, "html", join(root, "exports"));
+    const markdown = readFileSync(markdownPath, "utf8");
+    const html = readFileSync(htmlPath, "utf8");
+
+    assert.match(markdown, /# Report/);
+    assert.match(markdown, /2\.28M/);
+    assert.match(html, /Pi workflow report/);
+    assert.match(html, /Agent evidence/);
+    assert.match(html, /<table>/);
+    assert.match(html, /<td>Verified<\/td>/);
+    assert.match(html, /Synthesize the evidence/);
+    assert.doesNotMatch(html, /<script>alert/);
+    assert.match(html, /&lt;script&gt;alert/);
+  });
+
+  it("saves a reusable script without overwriting a different workflow", () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-script-"));
+    roots.push(root);
+    const first = completedRun();
+    const firstPath = saveWorkflowScript(first, root);
+    const secondPath = saveWorkflowScript({ ...first, script: `${first.script}\n// changed` }, root);
+    assert.equal(firstPath.endsWith("research-run.js"), true);
+    assert.notEqual(secondPath, firstPath);
+    assert.equal(readFileSync(firstPath, "utf8").includes("// changed"), false);
+  });
+
+  it("opens a completed run directly into its full result view", async () => {
+    initTheme(undefined, false);
+    const root = mkdtempSync(join(tmpdir(), "workflow-browser-"));
+    roots.push(root);
+    const manager = new WorkflowManager({
+      cwd: root,
+      runsDir: join(root, "runs"),
+      agent: async (prompt) => ({ output: `# Result\n\n${prompt}`, model: "test/model:low", tokens: 25, cost: 0.01 }),
+    });
+    await manager.runSync(`export const meta = { name: "browser", description: "Browser test", phases: ["Inspect"] };
+phase("Inspect");
+const report = await agent("inspect this", { label: "inspector", tier: "worker" });
+return { report };`);
+    const run = manager.listRuns()[0];
+    assert.ok(run);
+    manager.setSessionId("a-new-pi-session");
+    assert.equal(manager.listRuns().length, 0, "the session-scoped task list should be empty");
+    assert.equal(manager.listAllRuns().length, 1, "project history must survive a new Pi session");
+
+    const renders: string[][] = [];
+    const tui = { terminal: { rows: 30 }, requestRender() {} } as any;
+    const theme = {
+      fg: (_color: string, text: string) => text,
+      bold: (text: string) => text,
+    } as any;
+    const browser = new WorkflowRunBrowser(tui, theme, manager, root, {}, () => {}, () => {});
+    renders.push(browser.render(120));
+    assert.match(renders[0]?.join("\n") ?? "", /1 total/);
+    browser.handleInput("\r");
+    const resultView = browser.render(120).join("\n");
+    assert.match(resultView, /# Result|Result/);
+    assert.match(resultView, /Tokens: 25/);
+    browser.handleInput("\t");
+    browser.handleInput("\t");
+    browser.handleInput("\r");
+    const agentDetail = browser.render(120).join("\n");
+    assert.match(agentDetail, /Prompt/);
+    assert.match(agentDetail, /inspect this/);
+    browser.dispose();
+  });
+});

--- a/tests/workflow/runtime.test.ts
+++ b/tests/workflow/runtime.test.ts
@@ -38,6 +38,32 @@ describe("workflow runtime", () => {
     );
   });
 
+  it("normalizes generated string phases and an exported run wrapper", async () => {
+    const generated = `export const meta = {
+  name: "generated_shape",
+  description: "Shape emitted by a model",
+  phases: ["inspect", "synthesize"]
+};
+export default async function run() {
+  phase("inspect");
+  const finding = await agent("inspect", { label: "inspect", tier: "scout" });
+  return { finding };
+}`;
+    const parsed = parseWorkflowScript(generated);
+    assert.deepEqual(parsed.meta.phases?.map((phase) => phase.title), ["inspect", "synthesize"]);
+    assert.doesNotMatch(parsed.body, /export default/);
+
+    const root = mkdtempSync(join(tmpdir(), "workflow-generated-"));
+    roots.push(root);
+    const manager = new WorkflowManager({
+      cwd: root,
+      runsDir: join(root, "runs"),
+      agent: async (prompt) => ({ output: `done:${prompt}`, model: "test/model:low", tokens: 1, cost: 0 }),
+    });
+    const result = await manager.runSync(generated);
+    assert.equal(JSON.stringify(result.result), JSON.stringify({ finding: "done:inspect" }));
+  });
+
   it("executes fan-out/fan-in, persists history, and records usage", async () => {
     const root = mkdtempSync(join(tmpdir(), "workflow-runtime-"));
     roots.push(root);

--- a/tests/workflow/runtime.test.ts
+++ b/tests/workflow/runtime.test.ts
@@ -64,6 +64,64 @@ export default async function run() {
     assert.equal(JSON.stringify(result.result), JSON.stringify({ finding: "done:inspect" }));
   });
 
+  it("executes the generated agent-factory and phase-callback form from a plain run function", async () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-factory-"));
+    roots.push(root);
+    const prompts: string[] = [];
+    const manager = new WorkflowManager({
+      cwd: root,
+      runsDir: join(root, "runs"),
+      agent: async (prompt) => {
+        prompts.push(prompt);
+        return { output: `done:${prompts.length}`, model: "test/model:low", tokens: 1, cost: 0 };
+      },
+    });
+    const generated = `export const meta = {
+  name: "factory_shape",
+  description: "Shape emitted by the model",
+  phases: [{ title: "Discovery" }, { title: "Analysis" }]
+};
+async function run() {
+  const scout = agent("You are a documentation scout.", { tier: "scout" });
+  const researcher = agent("You are an architecture researcher.", { tier: "worker" });
+  const discovery = await phase("Discovery", async () => scout("List relevant files."));
+  return phase("Analysis", async () => researcher("Analyze " + discovery));
+}`;
+
+    const parsed = parseWorkflowScript(generated);
+    assert.doesNotMatch(parsed.body, /async function run/);
+    const result = await manager.runSync(generated);
+    assert.equal(result.result, "done:2");
+    assert.equal(result.agentCount, 2);
+    assert.match(prompts[0] ?? "", /documentation scout[\s\S]*Task:[\s\S]*List relevant files/);
+    assert.match(prompts[1] ?? "", /architecture researcher[\s\S]*Analyze done:1/);
+  });
+
+  it("awaits a trailing run() call instead of leaving an orphaned rejected promise", async () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-trailing-run-"));
+    roots.push(root);
+    const manager = new WorkflowManager({
+      cwd: root,
+      runsDir: join(root, "runs"),
+      agent: async (prompt) => ({ output: `done:${prompt}`, model: "test/model:low", tokens: 1, cost: 0 }),
+    });
+    const generated = `export const meta = {
+  name: "trailing_run",
+  description: "Await the invoked run function",
+  phases: [{ title: "Inspect" }]
+};
+const explorer = agent("You are an explorer.", { tier: "scout" });
+async function run() {
+  return explorer("Inspect the repository.");
+}
+run();`;
+    const parsed = parseWorkflowScript(generated);
+    assert.match(parsed.body, /return await run\(\)/);
+    const result = await manager.runSync(generated);
+    assert.equal(result.agentCount, 1);
+    assert.match(String(result.result), /done:You are an explorer/);
+  });
+
   it("executes fan-out/fan-in, persists history, and records usage", async () => {
     const root = mkdtempSync(join(tmpdir(), "workflow-runtime-"));
     roots.push(root);

--- a/tests/workflow/runtime.test.ts
+++ b/tests/workflow/runtime.test.ts
@@ -70,7 +70,13 @@ export default async function run() {
     const manager = new WorkflowManager({
       cwd: root,
       runsDir: join(root, "runs"),
-      agent: async (prompt) => ({ output: `done:${prompt}`, model: "test/model:low", tokens: 10, cost: 0.01 }),
+      agent: async (prompt) => ({
+        output: `done:${prompt}`,
+        model: "test/model:low",
+        tokens: 10,
+        cost: 0.01,
+        activity: [{ type: "tool_call" as const, name: "read", summary: "README.md" }],
+      }),
     });
     const result = await manager.runSync(workflowScript, undefined, { concurrency: 2, maxAgents: 5 });
     assert.equal(result.agentCount, 3);
@@ -78,6 +84,10 @@ export default async function run() {
     assert.equal(result.cost, 0.03);
     assert.deepEqual((result.result as any).findings, ["done:check a", "done:check b"]);
     assert.equal(manager.listRuns()[0].status, "completed");
+    assert.equal(manager.listRuns()[0].agents[0]?.prompt, "check a");
+    assert.deepEqual(manager.listRuns()[0].agents[0]?.activity, [
+      { type: "tool_call", name: "read", summary: "README.md" },
+    ]);
   });
 
   it("enforces the configured total-agent cap", async () => {

--- a/tests/workflow/runtime.test.ts
+++ b/tests/workflow/runtime.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { parseWorkflowScript, WorkflowManager } from "../../extensions/workflow/runtime.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+const workflowScript = `export const meta = {
+  name: "parallel_review",
+  description: "Run two checks and synthesize",
+  phases: [{ title: "Inspect" }, { title: "Synthesize" }]
+};
+phase("Inspect");
+const findings = await parallel([
+  () => agent("check a", { label: "check a", tier: "scout" }),
+  () => agent("check b", { label: "check b", tier: "worker" })
+]);
+phase("Synthesize");
+const summary = await agent("summarize " + findings.join(","), { label: "summary", tier: "synthesizer" });
+return { findings, summary };
+`;
+
+describe("workflow runtime", () => {
+  it("parses literal metadata without evaluating it", () => {
+    const parsed = parseWorkflowScript(workflowScript);
+    assert.equal(parsed.meta.name, "parallel_review");
+    assert.deepEqual(parsed.meta.phases?.map((phase) => phase.title), ["Inspect", "Synthesize"]);
+    assert.doesNotMatch(parsed.body, /export const meta/);
+    assert.throws(
+      () => parseWorkflowScript("export const meta = makeMeta(); return null;"),
+      /literal|object/,
+    );
+  });
+
+  it("executes fan-out/fan-in, persists history, and records usage", async () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-runtime-"));
+    roots.push(root);
+    const manager = new WorkflowManager({
+      cwd: root,
+      runsDir: join(root, "runs"),
+      agent: async (prompt) => ({ output: `done:${prompt}`, model: "test/model:low", tokens: 10, cost: 0.01 }),
+    });
+    const result = await manager.runSync(workflowScript, undefined, { concurrency: 2, maxAgents: 5 });
+    assert.equal(result.agentCount, 3);
+    assert.equal(result.tokens, 30);
+    assert.equal(result.cost, 0.03);
+    assert.deepEqual((result.result as any).findings, ["done:check a", "done:check b"]);
+    assert.equal(manager.listRuns()[0].status, "completed");
+  });
+
+  it("enforces the configured total-agent cap", async () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-runtime-"));
+    roots.push(root);
+    const manager = new WorkflowManager({
+      cwd: root,
+      runsDir: join(root, "runs"),
+      agent: async (prompt) => ({ output: prompt, model: "test/model:low", tokens: 1, cost: 0 }),
+    });
+    await assert.rejects(manager.runSync(workflowScript, undefined, { maxAgents: 2 }), /2-agent cap/);
+    assert.equal(manager.listRuns()[0].status, "failed");
+  });
+
+  it("rejects orchestration with no agents or a non-serializable result", async () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-runtime-"));
+    roots.push(root);
+    const manager = new WorkflowManager({
+      cwd: root,
+      runsDir: join(root, "runs"),
+      agent: async (prompt) => ({ output: prompt, model: "test/model:low", tokens: 1, cost: 0 }),
+    });
+    await assert.rejects(
+      manager.runSync('export const meta = { name: "empty", description: "empty" }; return {};'),
+      /must call agent/,
+    );
+    await assert.rejects(
+      manager.runSync(`export const meta = { name: "circular", description: "circular" };
+await agent("work", { label: "work", tier: "worker" });
+const result = {}; result.self = result; return result;`),
+      /JSON-serializable/,
+    );
+  });
+
+  it("rejects traversal-shaped run IDs", () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-runtime-"));
+    roots.push(root);
+    const runsDir = join(root, "runs");
+    const victim = join(root, "victim.json");
+    writeFileSync(victim, "keep");
+    const manager = new WorkflowManager({ cwd: root, runsDir });
+    assert.equal(manager.deleteRun("../../victim"), false);
+    assert.equal(existsSync(victim), true);
+  });
+
+  it("resumes a paused run from its unchanged journal prefix", async () => {
+    const root = mkdtempSync(join(tmpdir(), "workflow-runtime-"));
+    roots.push(root);
+    let calls = 0;
+    let releaseSecond: (() => void) | undefined;
+    const secondStarted = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    let unblock: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      unblock = resolve;
+    });
+    const manager = new WorkflowManager({
+      cwd: root,
+      runsDir: join(root, "runs"),
+      agent: async (prompt) => {
+        calls++;
+        if (calls === 2) {
+          releaseSecond?.();
+          await blocked;
+        }
+        return { output: `done:${prompt}`, model: "test/model:low", tokens: 1, cost: 0 };
+      },
+    });
+    const sequential = `export const meta = { name: "resume", description: "resume test" };
+const first = await agent("first", { label: "first", tier: "worker" });
+const second = await agent("second", { label: "second", tier: "worker" });
+return { first, second };
+`;
+    const { runId, promise } = manager.startInBackground(sequential);
+    await secondStarted;
+    assert.equal(manager.pause(runId), true);
+    unblock?.();
+    await assert.rejects(promise, /paused/);
+    assert.equal(manager.listRuns()[0].journal.length, 1);
+
+    const completed = new Promise<void>((resolve) => manager.once("complete", () => resolve()));
+    assert.equal(await manager.resume(runId), true);
+    await completed;
+    assert.equal(calls, 3, "the first agent should replay from cache during resume");
+    assert.equal(manager.listRuns()[0].status, "completed");
+  });
+});

--- a/tests/workflow/ui.test.ts
+++ b/tests/workflow/ui.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { WorkflowManager } from "../../extensions/workflow/runtime.js";
+import { installWorkflowResultDelivery } from "../../extensions/workflow/ui.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function harness() {
+  const root = mkdtempSync(join(tmpdir(), "workflow-delivery-"));
+  roots.push(root);
+  const manager = new WorkflowManager({
+    cwd: root,
+    runsDir: join(root, "runs"),
+    agent: async (prompt) => ({ output: `done:${prompt}`, model: "test/model:low", tokens: 1, cost: 0 }),
+  });
+  const messages: Array<{ content: string; options: unknown }> = [];
+  const pi = {
+    sendMessage(message: { content: string }, options: unknown) {
+      messages.push({ content: message.content, options });
+    },
+  } as any;
+  installWorkflowResultDelivery(pi, manager);
+  return { manager, messages };
+}
+
+describe("workflow result delivery", () => {
+  it("displays completion without waking the parent model for another tool turn", async () => {
+    const { manager, messages } = harness();
+    const { promise } = manager.startInBackground(`export const meta = { name: "complete", description: "Complete once" };
+return await agent("work", { label: "worker", tier: "worker" });`);
+    await promise;
+    assert.equal(messages.length, 1);
+    assert.deepEqual(messages[0]?.options, { triggerTurn: false });
+    assert.match(messages[0]?.content ?? "", /finished/);
+  });
+
+  it("displays failure once without triggering an automatic retry and approval loop", async () => {
+    const { manager, messages } = harness();
+    const { promise } = manager.startInBackground(`export const meta = { name: "fail", description: "Fail once" };
+await agent("work", { label: "worker", tier: "worker" });
+throw new Error("deliberate failure");`);
+    await assert.rejects(promise, /deliberate failure/);
+    assert.equal(messages.length, 1);
+    assert.deepEqual(messages[0]?.options, { triggerTurn: false });
+    assert.match(messages[0]?.content ?? "", /failed: deliberate failure/);
+  });
+});


### PR DESCRIPTION
## What changed

Adds a `/workflow` dynamic-workflow control plane for Pi.

- Configurable Lean, Balanced, Deep, and Custom profiles with role-based model and thinking routes
- Approval opens on the complete line-numbered JavaScript, requires an explicit `y`, and keeps routing/security details on a separate tab
- `/workflow help` provides an in-Pi quick-start, approval guide, command reference, result-inspection path, and failure behavior
- `/workflow doctor` performs a read-only readiness check covering activation, project trust, model routes, saved workflows, and run history without making model calls
- Trusted-project gating, background execution, durable run history, and pause/resume journals
- Saved project and personal JavaScript workflows, plus built-in code-review, repository-audit, and migration-plan workflows
- Unified interactive runs browser across Pi sessions with rendered Markdown results, progress and agent drill-down, generated-script inspection, and visible token/cost usage
- Agent prompt and recent tool-activity capture for new runs, with backward-compatible rendering for existing persisted runs
- Markdown and self-contained visual HTML report exports, open/copy actions, and save-as-reusable-workflow support
- Compatibility for generated `agent(persona)(task)`, `phase(title, callback)`, plain `run()` wrappers, and trailing `run();` scripts
- Display-only completion/failure delivery so a failed background run cannot wake the parent model into an automatic retry and re-approval loop
- Updated Pi SDK support to 0.80.10 and propagated extension-registered custom providers into subagents

## Why

This gives Pi a deliberate multi-agent workflow surface while preserving user control over lower-cost models, role-specific routes, scale limits, and execution approval.

The original approval showed only a derived summary, so the user could not inspect the code being authorized. Background failures were delivered as follow-up turns, which woke the parent model and caused repeated workflow calls and approval prompts. Generated scripts also commonly used callable agent personas, phase callbacks, or an un-awaited trailing `run();`; the runtime either recorded zero agents or allowed an orphaned rejection to crash Pi.

The original history UI persisted complete results but exposed only run IDs, statuses, and agent counts. It also filtered history to the current Pi session, making earlier project runs disappear after restart. The new browser makes the persisted report, evidence, orchestration, and usage inspectable and reusable.

The runtime is implemented locally against Pi's supported public SDK because the investigated upstream workflow package imports an SDK symbol no longer exported by current Pi.

## Validation

- `npm test` — 204 passing tests
- `npm run typecheck:workflow`
- `npm audit` — 0 vulnerabilities
- `npm pack --dry-run`
- `git diff --check`
- Live Pi 0.80.10 TUI validation with only the local workflow extension loaded
- Live `/workflow doctor` check reporting the extension active, project trusted, all four configured routes available, three saved workflows, and persisted history—with no model call
- Live `/workflow help` render validation covering setup, approval keys, inspection, controls, verification, and retry behavior
- Live approval regression check: JavaScript default tab, line-numbered scrolling, summary tab, and explicit rejection
- Deterministic replay of all four persisted scripts from the reported failures; they completed with 4, 2, 2, and 2 agents
- Cross-session inspection of an existing 6-agent, 2.28M-token persisted run
- Browser render validation of its 101 KB self-contained HTML report, including tables and expandable agent evidence

The validation did not make new paid-provider calls. It used deterministic local agents for the failed-script replays and reused an existing completed run for the browser/export checks.
