### PR TITLE
fix(ask-user): implement RPC mode via select/input dialogs

### DIFF
--- a/extensions/ask-user/README.md
+++ b/extensions/ask-user/README.md
@@ -36,6 +36,7 @@ LLM: Great! Creating microservice with PostgreSQL...
 ✅ **Custom answers** - "Other" option always available
 ✅ **Multiple questions** - Batch related questions
 ✅ **Print mode support** - Works in non-interactive mode
+✅ **RPC mode support** - Works over `pi --mode rpc` (e.g. cc-connect) via select/input dialogs
 ✅ **Session persistence** - Q&A stored in session history
 
 ## Question Types
@@ -95,6 +96,16 @@ pi -p @.pi/pending-questions.json "I prefer PostgreSQL"
 pi -c
 ```
 
+## RPC Mode
+
+When pi runs with `--mode rpc` (stdout is not a TTY), the UI is proxied to the
+host application, which only supports simple dialogs. In this mode:
+
+- Option questions use `ctx.ui.select()` — option descriptions are folded into
+  the label text, and an "Other" option is appended
+- "Other" and text questions use `ctx.ui.input()` as a follow-up
+- Multiple questions are asked sequentially
+
 ## Implementation Status
 
 **v0.1.0 - Current**
@@ -102,6 +113,7 @@ pi -c
 - ✅ Core tool logic
 - ✅ Schema validation
 - ✅ Print mode (pending file)
+- ✅ RPC mode (select/input dialogs)
 - ✅ Basic interactive mode (ctx.ui helpers)
 - ✅ Custom rendering
 - ⏸️ Custom TUI components (awaiting feedback)

--- a/extensions/ask-user/index.ts
+++ b/extensions/ask-user/index.ts
@@ -34,7 +34,7 @@ Guidelines:
         questions: params.questions,
         answers: result.answers,
         answeredAt: Date.now(),
-        mode: ctx.hasUI ? "interactive" : "print",
+        mode: !ctx.hasUI ? "print" : process.stdout.isTTY ? "interactive" : "rpc",
         metadata: params.metadata,
       };
 

--- a/extensions/ask-user/tool.ts
+++ b/extensions/ask-user/tool.ts
@@ -24,10 +24,16 @@ export async function executeAskUser(
 
 /**
  * Detect which mode we're running in
+ *
+ * RPC mode: the UI is proxied to a remote host (e.g. cc-connect) which only
+ * supports the simple dialog methods (select/confirm/input). In particular
+ * ctx.ui.custom() is NOT supported there (it resolves to undefined
+ * immediately, which would look like an instant cancel). The real TUI is
+ * only available when stdout is an actual terminal.
  */
 function detectMode(ctx: ExtensionContext): "interactive" | "print" | "rpc" {
   if (!ctx.hasUI) return "print";
-  // TODO: Detect RPC mode when implemented
+  if (!process.stdout.isTTY) return "rpc";
   return "interactive";
 }
 
@@ -76,14 +82,78 @@ async function executePrint(
 }
 
 /**
- * RPC mode - return structured request
+ * RPC mode - use simple proxied dialogs (select/input)
+ *
+ * The RPC UI protocol has no "custom component" concept, so the TUI option
+ * picker is replaced with ctx.ui.select(). The select method only carries
+ * plain strings, so option descriptions are folded into the label text.
+ * "Other" is offered as an extra option and followed up with ctx.ui.input(),
+ * mirroring the interactive flow.
  */
+const OTHER_LABEL = "Other (type your answer)";
+
 async function executeRpc(
   params: AskUserParams,
   ctx: ExtensionContext,
 ): Promise<AskUserResult> {
-  // TODO: Implement RPC mode
-  throw new Error("RPC mode not yet implemented");
+  const answers: Answer[] = [];
+
+  for (const question of params.questions) {
+    const answer = await askQuestionRpc(question, ctx);
+    if (!answer) {
+      return { answered: false, answers: [], cancelled: true };
+    }
+    answers.push(answer);
+  }
+
+  return { answered: true, answers };
+}
+
+async function askQuestionRpc(
+  question: Question,
+  ctx: ExtensionContext,
+): Promise<Answer | null> {
+  const title = question.header
+    ? `${question.header}\n\n${question.question}`
+    : question.question;
+
+  // No options -> plain text input question
+  if (!question.options?.length) {
+    const value = await ctx.ui.input(question.header ?? "Question", question.question);
+    if (value === undefined || value.trim() === "") return null;
+    return { question: question.question, answer: value, wasCustom: true };
+  }
+
+  // Options -> select dialog (descriptions appended to labels)
+  const labels = question.options.map(
+    (opt: NonNullable<Question["options"]>[number]) =>
+      opt.description ? `${opt.label} — ${opt.description}` : opt.label,
+  );
+  labels.push(OTHER_LABEL);
+
+  const selected = await ctx.ui.select(title, labels);
+  if (selected === undefined) return null;
+
+  if (selected === OTHER_LABEL) {
+    const value = await ctx.ui.input(question.header ?? "Question", question.question);
+    if (value === undefined || value.trim() === "") return null;
+    return {
+      question: question.question,
+      answer: value,
+      selectedOption: OTHER_LABEL,
+      wasCustom: true,
+    };
+  }
+
+  const idx = labels.indexOf(selected);
+  const label =
+    idx >= 0 && idx < question.options.length ? question.options[idx].label : selected;
+  return {
+    question: question.question,
+    answer: label,
+    selectedOption: label,
+    wasCustom: false,
+  };
 }
 
 /**

--- a/tests/ask-user/rpc-mode.test.ts
+++ b/tests/ask-user/rpc-mode.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { after, describe, it } from "node:test";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { executeAskUser } from "../../extensions/ask-user/tool.js";
+
+// Force the RPC code path: detectMode() treats a non-TTY stdout as RPC mode.
+// Each test file runs in its own process, so mutating isTTY is contained.
+const originalIsTTY = process.stdout.isTTY;
+Object.defineProperty(process.stdout, "isTTY", {
+  value: false,
+  configurable: true,
+  writable: true,
+});
+
+after(() => {
+  Object.defineProperty(process.stdout, "isTTY", {
+    value: originalIsTTY,
+    configurable: true,
+    writable: true,
+  });
+});
+
+interface MockUiState {
+  selectCalls: { title: string; options: string[] }[];
+  inputCalls: { title: string; placeholder?: string }[];
+  selectResults: (string | undefined)[];
+  inputResults: (string | undefined)[];
+}
+
+function mockRpcCtx(results: {
+  select?: (string | undefined)[];
+  input?: (string | undefined)[];
+}): { ctx: ExtensionContext; ui: MockUiState } {
+  const state: MockUiState = {
+    selectCalls: [],
+    inputCalls: [],
+    selectResults: [...(results.select ?? [])],
+    inputResults: [...(results.input ?? [])],
+  };
+
+  const ctx = {
+    hasUI: true,
+    ui: {
+      select: async (title: string, options: string[]) => {
+        state.selectCalls.push({ title, options });
+        return state.selectResults.shift();
+      },
+      input: async (title: string, placeholder?: string) => {
+        state.inputCalls.push({ title, placeholder });
+        return state.inputResults.shift();
+      },
+    },
+  } as unknown as ExtensionContext;
+
+  return { ctx, ui: state };
+}
+
+describe("executeAskUser RPC mode", () => {
+  it("asks a text question via ui.input", async () => {
+    const { ctx, ui } = mockRpcCtx({ input: ["John"] });
+
+    const result = await executeAskUser(
+      { questions: [{ question: "What is your name?" }] },
+      ctx,
+    );
+
+    assert.equal(result.answered, true);
+    assert.equal(ui.inputCalls.length, 1);
+    assert.equal(ui.inputCalls[0].placeholder, "What is your name?");
+    assert.deepEqual(result.answers, [
+      { question: "What is your name?", answer: "John", wasCustom: true },
+    ]);
+  });
+
+  it("asks an options question via ui.select, folding descriptions into labels", async () => {
+    const { ctx, ui } = mockRpcCtx({ select: ["Red — warm color"] });
+
+    const result = await executeAskUser(
+      {
+        questions: [
+          {
+            question: "Pick a color",
+            header: "Colors",
+            options: [
+              { label: "Red", description: "warm color" },
+              { label: "Blue" },
+            ],
+          },
+        ],
+      },
+      ctx,
+    );
+
+    assert.equal(result.answered, true);
+    assert.equal(ui.selectCalls.length, 1);
+    assert.equal(ui.selectCalls[0].title, "Colors\n\nPick a color");
+    assert.deepEqual(ui.selectCalls[0].options, [
+      "Red — warm color",
+      "Blue",
+      "Other (type your answer)",
+    ]);
+    // answer maps back to the original label, without the description suffix
+    assert.deepEqual(result.answers, [
+      {
+        question: "Pick a color",
+        answer: "Red",
+        selectedOption: "Red",
+        wasCustom: false,
+      },
+    ]);
+  });
+
+  it("follows up with ui.input when Other is selected", async () => {
+    const { ctx, ui } = mockRpcCtx({
+      select: ["Other (type your answer)"],
+      input: ["Chartreuse"],
+    });
+
+    const result = await executeAskUser(
+      {
+        questions: [
+          { question: "Pick a color", options: [{ label: "Red" }] },
+        ],
+      },
+      ctx,
+    );
+
+    assert.equal(result.answered, true);
+    assert.equal(ui.selectCalls.length, 1);
+    assert.equal(ui.inputCalls.length, 1);
+    assert.deepEqual(result.answers, [
+      {
+        question: "Pick a color",
+        answer: "Chartreuse",
+        selectedOption: "Other (type your answer)",
+        wasCustom: true,
+      },
+    ]);
+  });
+
+  it("reports cancellation when select is dismissed", async () => {
+    const { ctx } = mockRpcCtx({ select: [undefined] });
+
+    const result = await executeAskUser(
+      {
+        questions: [
+          { question: "Pick a color", options: [{ label: "Red" }] },
+        ],
+      },
+      ctx,
+    );
+
+    assert.equal(result.answered, false);
+    assert.equal(result.cancelled, true);
+    assert.deepEqual(result.answers, []);
+  });
+
+  it("asks multiple questions sequentially", async () => {
+    const { ctx, ui } = mockRpcCtx({
+      select: ["Red"],
+      input: ["John"],
+    });
+
+    const result = await executeAskUser(
+      {
+        questions: [
+          { question: "Pick a color", options: [{ label: "Red" }] },
+          { question: "What is your name?" },
+        ],
+      },
+      ctx,
+    );
+
+    assert.equal(result.answered, true);
+    assert.equal(ui.selectCalls.length, 1);
+    assert.equal(ui.inputCalls.length, 1);
+    assert.equal(result.answers.length, 2);
+    assert.equal(result.answers[0].selectedOption, "Red");
+    assert.equal(result.answers[1].answer, "John");
+  });
+});


### PR DESCRIPTION
## Problem

In RPC mode (`pi --mode rpc`, e.g. under cc-connect), `ask_user` questions with options instantly return "User cancelled" without showing anything to the user.

Root cause: the option picker is rendered with `ctx.ui.custom()`, which is a TUI-only API — in RPC mode `custom()` resolves to `undefined` immediately, which the extension interprets as a cancellation. Additionally, `detectMode()` always returned `"interactive"` whenever `hasUI` was true (the RPC detection was a TODO), so the `executeRpc` path was unreachable — and it just threw `RPC mode not yet implemented`.

## Fix

- **`detectMode()`**: treat non-TTY stdout as RPC mode (the real TUI is only available in a terminal)
- **Implement `executeRpc()`** using the dialog methods the RPC UI protocol does support:
  - option questions → `ctx.ui.select()`; option descriptions are folded into the label text (select only carries plain strings), and an "Other (type your answer)" option is appended
  - "Other" and text questions → `ctx.ui.input()` follow-up
  - multiple questions are asked sequentially, mirroring the interactive flow
- Report `mode: "rpc"` in tool result details
- Document RPC mode in the extension README
- Add `tests/ask-user/rpc-mode.test.ts` covering: text question, options with description folding, Other follow-up, cancellation, sequential questions

## Notes

- `multiSelect` remains single-select, matching the current interactive behavior.
- The `select`/`input` methods are part of the stable RPC UI protocol; RPC hosts such as cc-connect already render them as interactive cards (this is the same path extension permission prompts use).
- All 26 ask-user tests pass (21 existing + 5 new).